### PR TITLE
Remove Python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -26,7 +25,7 @@ install_requires =
     redis<=4.3.1
     six>=1.12
     sortedcontainers
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 lua =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}
+    py{38,39,310}
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
According to [`.github/workflows/test.yml`](https://github.com/dsoftwareinc/fakeredis-py/blob/master/.github/workflows/test.yml), fakeredis with python 3.7 has not been tested anymore since the release of the latest stable: v1.7.5. However, pypi says fakeredis still supports python 3.7, which comes from `setup.cfg`.