### PR TITLE
Create annotation for redis4+ tests

### DIFF
--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -5336,6 +5336,7 @@ class TestFakeStrictRedisConnectionErrors:
         with pytest.raises(redis.ConnectionError):
             r.llen('name')
 
+    @redis4_and_above
     def test_lmove(self, r):
         with pytest.raises(redis.ConnectionError):
             r.lmove(1, 2, 'LEFT', 'RIGHT')

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1260,6 +1260,7 @@ def test_linsert_wrong_type(r):
         r.linsert('foo', 'after', 'bar', 'element')
 
 
+@redis4_and_above
 def test_lmove(r):
     assert r.lmove('foo', 'bar', 'RIGHT', 'LEFT') is None
     assert r.lpop('bar') is None
@@ -1289,12 +1290,14 @@ def test_lmove(r):
     assert r.lrem('bar', -1, 'two') == 1
 
 
+@redis4_and_above
 def test_lmove_to_nonexistent_destination(r):
     r.rpush('foo', 'one')
     assert r.lmove('foo', 'bar', 'RIGHT', 'LEFT') == b'one'
     assert r.rpop('bar') == b'one'
 
 
+@redis4_and_above
 def test_lmove_expiry(r):
     r.rpush('foo', 'one')
     r.rpush('bar', 'two')
@@ -1303,6 +1306,7 @@ def test_lmove_expiry(r):
     assert r.ttl('bar') > 0
 
 
+@redis4_and_above
 def test_lmove_wrong_type(r):
     r.set('foo', 'bar')
     r.rpush('list', 'element')


### PR DESCRIPTION
Tests for `lmove` operation failed (see #11) due to redis-py version.
Create annotation for supporting tests from v4.1.2 and above.
See [redis-py changes in v4.1.2](https://github.com/redis/redis-py/blob/40fdb152641fcdf3be010cebe656331aa5709c2d/CHANGES#L19-L22)