### PR TITLE
23 - Re-add dependencies lost during switch to poetry

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -584,7 +584,7 @@ jeepney = ">=0.6"
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -592,7 +592,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -727,7 +727,7 @@ lua = ["lupa"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b59b4221e06e18de92c3074a735f994cf6df04268ac545e9c21291cadf70e40c"
+content-hash = "90e57af5f3415034d0b55a1c066b3c7ae00383a96c7330323574335b98765f60"
 
 [metadata.files]
 aioredis = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ python = "^3.8"
 lupa = { version = "^1.13", optional = true }
 redis = "<=4.3.1"
 aioredis = { version = "^2.0.1", optional = true }
+six = "^1.16.0"
+sortedcontainers = "^2.4.0"
 
 [tool.poetry.extras]
 lua = ["lupa"]


### PR DESCRIPTION
Fix for #23 

Looks like during the switch to poetry, the dependencies `six` and `sortedcontainers` were lost as primary dependencies. They still existed in the lockfile as dev dependencies, which is why I think they may have fallen through the cracks. 