### PR TITLE
Add GitHub release action to upload to PyPI & create GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    if: github.repository == 'dsoftwareinc/fakeredis-py'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U setuptools twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+          print_hash: true
+
+      - name: Create release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const tagName = context.ref.replace(/^refs\/tags\//, '');
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              generate_release_notes: true,
+            });
+
+            if (release.status < 200 || release.status >= 300) {
+              core.setFailed(`Could not create release for tag '${tagName}'`);
+              return;
+            }
+
+  # https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2
+  create-issue-on-failure:
+    name: Create an issue if release failed
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.repository == 'dsoftwareinc/fakeredis-py' && always() && needs.build.result == 'failure' }}
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Release failure on ${new Date().toDateString()}`,
+              body: `Details: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/release.yml`,
+            })


### PR DESCRIPTION
I recently added this action to django-stubs and figured you might want it https://github.com/typeddjango/django-stubs/pull/980 (I noticed you created a release, but hadn't updated PyPI so this would take care of all of that when pushing a tag)