### PR TITLE
Fix input and output type of cursors for SCAN commands

### DIFF
--- a/fakeredis/_helpers.py
+++ b/fakeredis/_helpers.py
@@ -912,6 +912,7 @@ class FakeSocket:
         However, provided the database is not modified, every key will be
         returned exactly once.
         """
+        cursor = int(cursor)
         pattern = None
         type = None
         count = 10
@@ -955,7 +956,7 @@ class FakeSocket:
 
         if result_cursor >= len(data):
             result_cursor = 0
-        return [result_cursor, result_data]
+        return [str(result_cursor).encode(), result_data]
 
     # Connection commands
     # TODO: auth, quit

--- a/test/test_lua.py
+++ b/test/test_lua.py
@@ -486,3 +486,19 @@ def test_lua_log_defined_vars(r, caplog):
     with caplog.at_level('DEBUG'):
         script()
     assert caplog.record_tuples == [(logger.name, logging.DEBUG, 'string')]
+
+
+def test_hscan_cursors_are_bytes(r):
+    r.hset('hkey', 'foo', 1)
+
+    result = r.eval(
+        """
+        local results = redis.call("HSCAN", KEYS[1], "0")
+        return results[1]
+        """,
+        1,
+        'hkey'
+    )
+
+    assert result == b'0'
+    assert isinstance(result, bytes)


### PR DESCRIPTION
Cursors are bytes in redis: https://redis.io/commands/scan/