### PR TITLE
fix(tcp_server): clean up handler threads on shutdown

### DIFF
--- a/fakeredis/_tcp_server.py
+++ b/fakeredis/_tcp_server.py
@@ -8,6 +8,7 @@ except ImportError:
     HAS_FCNTL = False
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass
 from io import BufferedIOBase
@@ -164,7 +165,7 @@ class TCPFakeRequestHandler(StreamRequestHandler):
 
     def handle(self) -> None:
         LOGGER.debug(f"+++ {self.client_address[0]} connected")
-        while True:
+        while not self.server._shutdown_event.is_set():
             try:
                 if self.shutdown_request:
                     break
@@ -202,11 +203,16 @@ class TcpFakeServer(ThreadingTCPServer):
         server_version: VersionType = (8, 0),
     ):
         self.allow_reuse_address = True
-        self.daemon_threads = True
+        self.daemon_threads = False
+        self._shutdown_event = threading.Event()
         super().__init__(server_address, TCPFakeRequestHandler, bind_and_activate)
         self.fake_server = FakeServer(server_type=server_type, version=server_version)
         self.client_ids = count(0)
         self.clients: Dict[int, FakeRedisConnection] = {}
+
+    def shutdown(self) -> None:
+        self._shutdown_event.set()
+        super().shutdown()
 
 
 TCP_SERVER_TEST_PORT = 19000

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -87,8 +87,8 @@ def _tcp_fake_server() -> Generator[tuple[str, int], Any, None]:
     t.start()
     time.sleep(0.1)
     yield server_address
-    server.server_close()
     server.shutdown()
+    server.server_close()
     t.join()
 
 

--- a/test/test_tcp_server/test_connectivity.py
+++ b/test/test_tcp_server/test_connectivity.py
@@ -1,7 +1,12 @@
+import threading
+import time
+from threading import Thread
 from typing import Tuple
 
 import pytest
 import redis
+
+from fakeredis._tcp_server import TcpFakeServer
 
 
 pytestmark = []
@@ -47,3 +52,29 @@ def test_tcp_server_started_protocol_3(tcp_server_address: Tuple[str, int]):
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1], protocol=3) as r:
         r.set("foo", "bar")
         assert r.get("foo") == b"bar"
+
+
+def test_tcp_server_clean_shutdown():
+    """Verify that shutdown() + server_close() leaves no lingering handler threads."""
+    port = 19100
+    server = TcpFakeServer(("127.0.0.1", port))
+    t = Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    time.sleep(0.05)
+
+    threads_before = set(threading.enumerate())
+
+    with redis.Redis(host="127.0.0.1", port=port) as r:
+        r.set("k", "v")
+        assert r.get("k") == b"v"
+
+    # Allow handler thread to be created
+    time.sleep(0.05)
+    handler_threads = set(threading.enumerate()) - threads_before
+
+    server.shutdown()
+    server.server_close()
+
+    for ht in handler_threads:
+        ht.join(timeout=2.0)
+        assert not ht.is_alive(), f"Handler thread {ht.name} is still alive after shutdown"


### PR DESCRIPTION
## Summary

Fixes #474

- `TcpFakeServer` had `daemon_threads = True`, so handler threads (one per client connection) were never tracked or joined by `server_close()`. They leaked until the process exited, causing test frameworks that detect thread leaks to fail.
- The `handle()` loop had no way to observe the server's shutdown state — it only exited via an inaccessible per-handler `shutdown_request` flag — so threads spun indefinitely after `shutdown()` was called.
- The `conftest.py` fixture called `server_close()` before `shutdown()`, which is the wrong order.

**Changes:**
- Add `_shutdown_event` (`threading.Event`) to `TcpFakeServer`; set it in an overridden `shutdown()` before delegating to `super()`
- Check `self.server._shutdown_event.is_set()` as the `handle()` loop condition so every handler thread exits promptly on server shutdown
- Switch `daemon_threads` to `False` so `server_close()` / `block_on_close` properly joins them
- Fix conftest cleanup order: `shutdown()` → `server_close()` → `t.join()`
- Add `test_tcp_server_clean_shutdown` regression test

## Test plan

- [ ] All 11 existing TCP server tests pass
- [ ] New `test_tcp_server_clean_shutdown` confirms handler threads are gone after `shutdown()` + `server_close()`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)