### PR TITLE
Fix typo in vectorset jsonpath dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ valkey = [
 ]
 vectorset = [
     "numpy>=2.4.0 ; python_version >= '3.11'",
-    "jsonpath_ng>=1.6 ; python_version >= '3.11'",
+    "jsonpath-ng>=1.6 ; python_version >= '3.11'",
 ]
 
 [project.urls]


### PR DESCRIPTION
json optional dependency had "jsonpath-ng" while vectorset had "jsonpath_ng". It resolves to the correct jsonpath-ng, but it looks strange having the same dependency with different naming.