### PR TITLE
fix: Make module-level pytest.skip work properly

### DIFF
--- a/test/test_mixins/test_specific_redis_versions/test_redis_8_4_msetex.py
+++ b/test/test_mixins/test_specific_redis_versions/test_redis_8_4_msetex.py
@@ -10,7 +10,7 @@ pytest.importorskip("jsonpath_ng")
 try:
     from redis.commands.core import DataPersistOptions
 except ImportError:
-    pytest.skip()
+    pytest.skip(allow_module_level=True)
 
 from test.testtools import raw_command
 


### PR DESCRIPTION
This requires `allow_module_level=True`, which has been accepted since pytest 3.3.0.