### PR TITLE
fix(async): _decode recurses into dict for RESP3 HGETALL

### DIFF
--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -163,6 +163,8 @@ class FakeBaseAsyncConnection(FakeBaseConnectionMixin):
     def _decode(self, response: Any) -> Any:
         if isinstance(response, list):
             return [self._decode(item) for item in response]
+        elif isinstance(response, dict):
+            return {self._decode(k): self._decode(v) for k, v in response.items()}
         elif isinstance(response, bytes):
             return self.encoder.decode(response)
         else:

--- a/test/test_async/test_asyncredis.py
+++ b/test/test_async/test_asyncredis.py
@@ -121,6 +121,21 @@ async def test_never_decode(async_redis: AsyncClientType):
     assert isinstance(bytestr, bytes)
 
 
+@pytest.mark.decode_responses
+async def test_hgetall_decodes_under_decode_responses(async_redis: AsyncClientType):
+    """Regression: async HGETALL under decode_responses=True must return
+    str keys/values across both RESP2 and RESP3. On RESP3 the server
+    returns a native ``dict``; the async ``_decode`` previously walked
+    ``list``/``bytes`` only, leaving the dict's contents as raw bytes.
+    """
+    await async_redis.hset("h", mapping={"status": "ok", "token": "tok"})
+    result = await async_redis.hgetall("h")
+    assert result == {"status": "ok", "token": "tok"}
+    for k, v in result.items():
+        assert isinstance(k, str), f"hash key {k!r} should be str"
+        assert isinstance(v, str), f"hash value {v!r} should be str"
+
+
 async def test_type(async_redis: AsyncClientType):
     await async_redis.set("string_key", "value")
     await async_redis.lpush("list_key", "value")


### PR DESCRIPTION
Fixes #491.

## Summary

`fakeredis.aioredis.FakeRedis(decode_responses=True, protocol=3).hgetall(...)` was returning `{bytes: bytes}` instead of `{str: str}` because the async `_decode` in `fakeredis/aioredis.py` walked only `list` and `bytes`. Under RESP2 the server flattened HGETALL into a list so the missing branch was harmless; under RESP3 the server returns a native `dict` and `_decode` returned it unchanged.

The sync `_decode` in `fakeredis/_connection.py` already handles `dict` — this PR just mirrors that branch on the async side.

Because `redis-py 8.0.0` defaulted the protocol to RESP3, any async caller relying on `decode_responses=True` started seeing bytes from HGETALL after upgrading.

## Repro (before the patch)

```python
import asyncio, fakeredis.aioredis

async def main():
    r = fakeredis.aioredis.FakeRedis(decode_responses=True, protocol=3)
    await r.hset("h", mapping={"k": "v"})
    print(await r.hgetall("h"))   # {b'k': b'v'}   ← bug

asyncio.run(main())
```

After the patch the output is `{'k': 'v'}`.

## Changes

- `fakeredis/aioredis.py`: add `dict` branch to `_decode`, mirroring the sync version.
- `test/test_async/test_asyncredis.py`: regression test `test_hgetall_decodes_under_decode_responses` that asserts `str` keys/values and runs across the four combinations the async fixture already parametrizes (`fake/real` × `RESP2/RESP3`). I verified locally that the new test fails on `fake_resp3` without the fix and passes on all four with it.

## Test plan

- [x] `pytest test/test_async/test_asyncredis.py -k hgetall_decodes` — 4 passed (fake/real × resp2/resp3).
- [x] Existing `test_types` and `test_never_decode` still pass.
- [x] Manual repro returns `{'status': 'ok', 'token': 'tok'}` with the patch.