### PR TITLE
fix: import redis.asyncio explicitly so import works on redis-py < 5

### DIFF
--- a/fakeredis/_typing.py
+++ b/fakeredis/_typing.py
@@ -2,6 +2,7 @@ import sys
 from typing import Tuple, Union, Dict, Any, List, Type
 
 import redis
+import redis.asyncio  # redis-py < 5 does not import this submodule via ``import redis``
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -29,6 +30,7 @@ ClientType = redis.Redis
 AsyncClientType = redis.asyncio.Redis
 try:
     import valkey
+    import valkey.asyncio  # imported explicitly for the same reason as redis.asyncio
 
     ClientType = Union[redis.Redis, valkey.Valkey]  # type: ignore[misc, assignment]
     AsyncClientType = Union[redis.asyncio.Redis, valkey.asyncio.Valkey]  # type: ignore[misc, assignment]

--- a/test/test_internals/test_typing_imports.py
+++ b/test/test_internals/test_typing_imports.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+
+import redis
+
+
+def test_typing_imports_without_preimported_redis_asyncio(monkeypatch):
+    """Regression test for #493.
+
+    redis-py < 5 does not bind the ``redis.asyncio`` submodule on a plain
+    ``import redis``. ``fakeredis._typing`` references ``redis.asyncio.Redis``
+    at module level, so without an explicit ``import redis.asyncio`` importing
+    fakeredis raised ``AttributeError: module 'redis' has no attribute
+    'asyncio'`` at import time. Here we reproduce that state regardless of the
+    installed redis-py version by removing the cached submodule, then check
+    that re-importing ``_typing`` succeeds.
+    """
+    monkeypatch.delattr(redis, "asyncio", raising=False)
+    monkeypatch.delitem(sys.modules, "redis.asyncio", raising=False)
+    monkeypatch.delitem(sys.modules, "fakeredis._typing", raising=False)
+
+    module = importlib.import_module("fakeredis._typing")
+
+    assert module.AsyncClientType is not None


### PR DESCRIPTION
## Problem

Importing fakeredis fails at import time when redis-py < 5 is installed (the project supports `redis>=4.3` for Python > 3.8, and the CI matrix includes `redis-py: 4.6.0`):

```
AttributeError: module 'redis' has no attribute 'asyncio'
```

raised from `fakeredis/_typing.py` line 29.

## Cause

`_typing.py` does `import redis` and then references `redis.asyncio.Redis` at module level. On redis-py >= 5, `import redis` happens to pull in the `redis.asyncio` submodule, so the attribute exists. On redis-py < 5 it does not — the submodule has to be imported explicitly — so the attribute access raises `AttributeError` and `import fakeredis` blows up before anything runs. The `valkey` branch a few lines down has the same shape (`import valkey` then `valkey.asyncio.Valkey`).

## Fix

Import the submodules explicitly: `import redis.asyncio` (and `import valkey.asyncio` inside the existing `try`). This is harmless on redis-py >= 5 and fixes the import on < 5.

## Verification

- Reproduced with `redis==4.6.0`: `import fakeredis` raised the `AttributeError`; with the fix it imports and basic ops work.
- Still imports fine on `redis==8.0.0`.
- Added `test/test_internals/test_typing_imports.py`, which reproduces the redis < 5 state (removes the cached `redis.asyncio`) and re-imports `fakeredis._typing`. It fails on `master` (`AttributeError`) and passes with the fix, independent of the installed redis-py version.

Closes #493.