### PR TITLE
ci: fix stale test paths in dragonfly workflow matrix

### DIFF
--- a/.github/workflows/test-dragonfly.yml
+++ b/.github/workflows/test-dragonfly.yml
@@ -19,13 +19,10 @@ jobs:
           - "test_json"
           - "test_mixins"
           - "test_stack"
-          - "test_connection.py"
-          - "test_asyncredis.py"
-          - "test_general.py"
-          - "test_scan.py"
-          - "test_zadd.py"
-          - "test_translations.py"
-          - "test_sortedset_commands.py"
+          - "test_async"
+          - "test_internals"
+          - "test_transactions.py"
+          - "test_keyspace_notifications.py"
     permissions:
       pull-requests: write
     services:


### PR DESCRIPTION
## Summary
The `workflow_dispatch` dragonfly test workflow runs `pytest test/<matrix entry>`, but most file-level matrix entries point at paths that no longer exist at the top of `test/`:

- `test_connection.py`, `test_scan.py`, `test_zadd.py`, `test_sortedset_commands.py` — moved into `test/test_mixins/` (already covered by the `test_mixins` entry)
- `test_asyncredis.py` — lives in `test/test_async/` and `test/test_internals/`
- `test_translations.py`, `test_general.py` — don't exist (the former looks like a typo for `test_transactions.py`)

These jobs fail immediately with "file or directory not found".

## Changes
Replace the stale entries with paths that exist: `test_async`, `test_internals`, `test_transactions.py`, `test_keyspace_notifications.py` (alongside the existing `test_json`, `test_mixins`, `test_stack`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)