### PR TITLE
fix: replace can_read busy-poll with event-based wakeup

### DIFF
--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import warnings
 from typing import Any, Callable, Iterable, Optional, Sequence, Set, Type, Union
 
@@ -21,6 +22,11 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.responses: asyncio.Queue = asyncio.Queue()  # type:ignore
+        # Set whenever a response is enqueued so can_read() can wait on it
+        # instead of polling the queue (see can_read).
+        self._response_available: asyncio.Event = asyncio.Event()
+        self._event_loop = asyncio.get_running_loop()
+        self._loop_thread_ident = threading.get_ident()
 
     def _decode_error(self, error: SimpleError) -> ResponseError:
         parser = DefaultParser(1)
@@ -30,6 +36,17 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
         if not self.responses:
             return
         self.responses.put_nowait(msg)
+        if threading.get_ident() == self._loop_thread_ident:
+            self._response_available.set()
+        else:
+            # Called from another thread, e.g. a sync client publishing to a
+            # channel this socket subscribes to on a shared FakeServer: a plain
+            # set() would not wake this socket's sleeping event loop, so the
+            # wakeup must be marshalled through it.
+            try:
+                self._event_loop.call_soon_threadsafe(self._response_available.set)
+            except RuntimeError:  # the loop is already closed
+                pass
 
     async def _async_blocking(
         self,
@@ -141,17 +158,33 @@ class FakeBaseAsyncConnection(FakeBaseConnectionMixin):
             await self.connect()
         if timeout == 0:
             return self._sock is not None and not self._sock.responses.empty()
-        # asyncio.Queue doesn't have a way to wait for the queue to be
-        # non-empty without consuming an item, so kludge it with a sleep/poll
-        # loop.
+        # asyncio.Queue has no "wait until non-empty without consuming" API, so
+        # wait on the socket's _response_available event (set by put_response)
+        # rather than polling. timeout=None waits indefinitely.
+        #
+        # The event is only cleared here, never by the consumers that drain the
+        # queue (responses.get / get_nowait), so "event set" does NOT imply
+        # "queue non-empty" -- it may be left set after the queue was drained.
+        # The recheck of empty() immediately after clear() is therefore
+        # mandatory, not an optimization: it both closes the lost-wakeup race
+        # (an item enqueued between the empty() check and the wait) and absorbs
+        # a stale set. Do not remove it.
         loop = asyncio.get_event_loop()
         start = loop.time()
         while True:
-            if self._sock and not self._sock.responses.empty():
+            if self._sock is None:
+                return False
+            if not self._sock.responses.empty():
                 return True
-            await asyncio.sleep(0.01)
-            now = loop.time()
-            if timeout is not None and now > start + timeout:
+            self._sock._response_available.clear()
+            if not self._sock.responses.empty():  # mandatory recheck, see above
+                return True
+            remaining = None if timeout is None else timeout - (loop.time() - start)
+            if remaining is not None and remaining <= 0:
+                return False
+            try:
+                await asyncio.wait_for(self._sock._response_available.wait(), remaining)
+            except asyncio.TimeoutError:
                 return False
 
     async def _get_from_local_cache(self, command: Sequence[str]) -> None:

--- a/test/test_async/test_asyncredis.py
+++ b/test/test_async/test_asyncredis.py
@@ -1,11 +1,15 @@
 import asyncio
 import sys
+import threading
+import time
+from unittest import mock
 
 import pytest
 import redis
 import redis.asyncio
 import valkey
 
+import fakeredis
 from fakeredis import FakeServer, aioredis
 from fakeredis._typing import async_timeout, AsyncClientType
 from test import testtools
@@ -95,6 +99,60 @@ async def test_pubsub_disconnect(async_redis: AsyncClientType):
         assert message is not None
         message = await ps.get_message(timeout=0.5)
         assert message is None
+
+
+async def test_get_message_timeout_does_not_busy_poll(async_redis: AsyncClientType):
+    """Waiting for a response must be event-driven, not a poll loop.
+
+    ``can_read`` used to wait for the response queue to become non-empty by
+    looping over ``asyncio.sleep(0.01)``, waking the event loop 100 times a
+    second for every idle reader. Waiting out a ``get_message`` timeout must
+    not call ``asyncio.sleep`` at all.
+    """
+    async with async_redis.pubsub() as ps:
+        await ps.subscribe("channel")
+        message = await ps.get_message(timeout=5)
+        assert message["type"] == "subscribe"
+
+        with mock.patch("asyncio.sleep", wraps=asyncio.sleep) as sleep_spy:
+            message = await ps.get_message(timeout=0.3)
+        assert message is None
+        assert sleep_spy.call_count == 0
+
+
+async def test_pubsub_publish_from_another_thread(async_redis: AsyncClientType, request, real_server_details):
+    """Regression: a sync client publishing from another thread must wake an
+    async subscriber promptly. ``can_read`` waits on an ``asyncio.Event`` set
+    by ``put_response``, which runs on the publisher's thread here, so the
+    wakeup must go through ``call_soon_threadsafe`` -- otherwise the
+    subscriber's event loop is not woken and the message is only seen once
+    the ``get_message`` timeout expires.
+    """
+    is_fake = isinstance(async_redis, (fakeredis.FakeAsyncRedis, fakeredis.FakeAsyncValkey))
+    is_valkey = real_server_details.server_type == "valkey"
+    if is_fake:
+        sync_cls = fakeredis.FakeValkey if is_valkey else fakeredis.FakeStrictRedis
+        publisher = sync_cls(server=request.getfixturevalue("fake_server"))
+    else:
+        sync_cls = valkey.StrictValkey if is_valkey else redis.StrictRedis
+        publisher = sync_cls("localhost", port=6390, db=2)
+
+    async with async_redis.pubsub() as ps:
+        await ps.subscribe("channel")
+        message = await ps.get_message(timeout=5)
+        assert message["type"] == "subscribe"
+
+        timer = threading.Timer(0.1, publisher.publish, args=("channel", "hello"))
+        timer.start()
+        start = time.monotonic()
+        message = await ps.get_message(timeout=5)
+        elapsed = time.monotonic() - start
+        timer.join()
+        assert message == {"channel": b"channel", "pattern": None, "type": "message", "data": b"hello"}
+        # Generous bound: delivery should take ~0.1s; the failure mode is
+        # waiting out the full 5s get_message timeout.
+        assert elapsed < 2.5
+    publisher.close()
 
 
 async def test_wrongtype_error(async_redis: AsyncClientType):


### PR DESCRIPTION
`can_read` waited for responses by checking the queue and `asyncio.sleep(0.01)` in a loop.

It now waits on a per-socket `asyncio.Event` that `put_response` sets whenever it enqueues a response.

Effect:

- An idle reader no longer wakes the event loop 100 times per second: waiting out a `get_message` timeout makes zero `asyncio.sleep` calls.
- A consumer waiting on `get_message` now sees the message in <0.1ms instead of up to 10ms.
- Regular command throughput is unchanged (~20k sequential SET/GET ops/s before and after).

### How it works

- `can_read` only checks that a response is ready; `read_response` then takes it off a queue it knows is non-empty. The one-step alternative, `wait_for(queue.get(), timeout)`, can drop a response when the timeout fires just as the item arrives (python/cpython#92824).
- Before waiting, `can_read` clears the event and then re-checks the queue. The clear is needed because the event may still be set from a response that was already consumed; the re-check catches a response that arrived just before the clear.
- When a sync client and an async client share one `FakeServer`, a publish from the sync side runs `put_response` on the sync client's thread. In that case the event is set through `call_soon_threadsafe`; a plain `set()` from another thread would not wake the async client's event loop.

### Tests

- `test_get_message_timeout_does_not_busy_poll` — waiting out a `get_message` timeout must never call `asyncio.sleep`.
- `test_pubsub_publish_from_another_thread` — a message published from a sync client thread must arrive promptly.

Not related to #471. Issue behaves the same before and after this change.

<details>
<summary>Benchmark script</summary>

Self-contained: save and run with `python bench.py` in an environment with fakeredis installed. No redis server needed.

```python
import asyncio
import time

from fakeredis.aioredis import FakeRedis


async def bench_commands(n: int = 20000) -> float:
    r = FakeRedis()
    await r.ping()
    t0 = time.perf_counter()
    for _ in range(n):
        await r.set("k", "v")
        await r.get("k")
    dt = time.perf_counter() - t0
    await r.aclose()
    return 2 * n / dt


async def bench_pubsub_wakeup(n: int = 200) -> float:
    """Round trips where the consumer is already waiting when publish happens."""
    r = FakeRedis()
    ps = r.pubsub()
    await ps.subscribe("ch")
    assert (await ps.get_message(timeout=1))["type"] == "subscribe"
    t0 = time.perf_counter()
    for _ in range(n):
        waiter = asyncio.ensure_future(ps.get_message(timeout=5))
        for _ in range(10):  # let the waiter reach its wait
            await asyncio.sleep(0)
        await r.publish("ch", "x")
        m = await waiter
        assert m and m["data"] == b"x"
    dt = time.perf_counter() - t0
    await ps.aclose()
    await r.aclose()
    return n / dt


async def main() -> None:
    print(f"commands: {max([await bench_commands() for _ in range(3)]):,.0f} ops/sec")
    rate = max([await bench_pubsub_wakeup() for _ in range(3)])
    print(f"pubsub wakeup: {1000 / rate:.2f} ms per round trip")


asyncio.run(main())
```

</details>