### PR TITLE
fix: enforce GT/LT conditions in ZADD with INCR

### DIFF
--- a/fakeredis/commands_mixins/sortedset_mixin.py
+++ b/fakeredis/commands_mixins/sortedset_mixin.py
@@ -147,6 +147,11 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             item_score, item_name = items[0]
             if (nx and item_name in zset) or (xx and item_name not in zset):
                 return None
+            if (gt or lt) and item_name in zset:
+                current_score = zset.get(item_name)
+                new_score = current_score + item_score
+                if (gt and new_score <= current_score) or (lt and new_score >= current_score):
+                    return None
             return self.zincrby(key, item_score, item_name)  # type: ignore[no-any-return]
         count = [nx, gt, lt, xx].count(True)
         for item_score, item_name in items:

--- a/test/test_mixins/test_sortedset_zadd.py
+++ b/test/test_mixins/test_sortedset_zadd.py
@@ -188,6 +188,23 @@ def test_zadd_incr(r: ClientType, ch: bool):
     assert r.zadd("foo", {"three": 1.0}, incr=True, xx=True, ch=ch) == 4.0
 
 
+def test_zadd_incr_with_gt_and_lt(r: ClientType):
+    r.zadd("foo", {"m": 5.0})
+    # GT + INCR: a decrement makes the new score not greater -> aborted, returns None, score unchanged
+    assert r.zadd("foo", {"m": -1.0}, incr=True, gt=True) is None
+    assert r.zscore("foo", "m") == 5.0
+    # GT + INCR: an increment makes the new score greater -> applied
+    assert r.zadd("foo", {"m": 3.0}, incr=True, gt=True) == 8.0
+    # LT + INCR: an increment makes the new score not less -> aborted
+    assert r.zadd("foo", {"m": 1.0}, incr=True, lt=True) is None
+    assert r.zscore("foo", "m") == 8.0
+    # LT + INCR: a decrement makes the new score less -> applied
+    assert r.zadd("foo", {"m": -2.0}, incr=True, lt=True) == 6.0
+    # GT/LT do not prevent adding a brand-new member
+    assert r.zadd("foo", {"new": 2.0}, incr=True, gt=True) == 2.0
+    assert r.zscore("foo", "new") == 2.0
+
+
 def test_zadd_with_xx_and_gt_and_ch(r: ClientType):
     r.zadd("test", {"one": 1})
     assert r.zscore("test", "one") == 1.0


### PR DESCRIPTION
## The bug

`ZADD` with `GT`/`LT` combined with `INCR` ignored the conditional and always applied the increment:

```python
r.zadd("z", {"m": 5})
r.zadd("z", {"m": -1}, gt=True, incr=True)   # returns 4.0, sets score to 4.0
```

Per the [`ZADD` docs](https://redis.io/docs/latest/commands/zadd/), with `INCR` the new score is `current + increment`, and `GT`/`LT` only update the element when that new score is greater (resp. less) than the current one. When the condition is not met the command must return `nil` and leave the score unchanged — so the call above should return `None` and keep the score at `5`.

`NX`/`XX` were already enforced on the `INCR` path; only `GT`/`LT` were missing.

## The fix

In `SortedSetCommandsMixin.zadd`, before applying the increment, check the `GT`/`LT` condition against the resulting score and return `None` (without modifying the set) when it is not satisfied. The check is skipped when the member does not yet exist, so `GT`/`LT` still add brand-new members, as documented.

## Verification

Added `test_zadd_incr_with_gt_and_lt` covering: GT/LT reject (score unchanged), GT/LT apply, and adding a new member. The test passes against both fakeredis and a real Redis 8.8.0 server; before the fix the fakeredis cases fail (e.g. `assert 4.0 is None`) while real Redis passes, confirming the parity gap.