### PR TITLE
fix: SORT/SORT_RO BY <constant> must keep natural order

### DIFF
--- a/fakeredis/commands_mixins/generic_mixin.py
+++ b/fakeredis/commands_mixins/generic_mixin.py
@@ -288,7 +288,10 @@ class GenericCommandsMixin(CommandsMixinBase):
 
             sort_func = sort_key if alpha else sort_key_score
             items.sort(key=sort_func, reverse=desc)
-        elif isinstance(key.value, (list, ZSet)):
+        # A `BY` pattern with no `*` means "don't sort": keep natural order
+        # (insertion order for lists, score order for zsets) and only reverse
+        # when DESC is given.
+        elif desc and isinstance(key.value, (list, ZSet)):
             items.reverse()
 
         out = []
@@ -371,7 +374,10 @@ class GenericCommandsMixin(CommandsMixinBase):
 
             sort_func = sort_key if alpha else sort_key_score
             items.sort(key=sort_func, reverse=desc)
-        elif isinstance(key.value, (list, ZSet)):
+        # A `BY` pattern with no `*` means "don't sort": keep natural order
+        # (insertion order for lists, score order for zsets) and only reverse
+        # when DESC is given.
+        elif desc and isinstance(key.value, (list, ZSet)):
             items.reverse()
 
         out: List[bytes] = []

--- a/fakeredis/commands_mixins/generic_mixin.py
+++ b/fakeredis/commands_mixins/generic_mixin.py
@@ -261,9 +261,8 @@ class GenericCommandsMixin(CommandsMixinBase):
 
             sort_func = sort_key if alpha else sort_key_score
             items.sort(key=sort_func, reverse=desc)
-        # A `BY` pattern with no `*` means "don't sort": keep natural order
-        # (insertion order for lists, score order for zsets) and only reverse
-        # when DESC is given.
+        # A `BY` pattern with no `*` means "don't sort": keep natural order (insertion order for lists, score order for
+        # zsets) and only reverse when DESC is given.
         elif desc and isinstance(key.value, (list, ZSet)):
             items.reverse()
 

--- a/test/test_mixins/test_generic_commands.py
+++ b/test/test_mixins/test_generic_commands.py
@@ -231,9 +231,8 @@ def test_sort_with_by_and_get_option(r: ClientType):
 
 
 def test_sort_by_nosort_keeps_natural_order(r: ClientType):
-    # A `BY` pattern with no `*` disables sorting: redis returns elements in
-    # natural order (insertion order for lists, score order for sorted sets)
-    # and reverses only when DESC is given.
+    # A `BY` pattern with no `*` disables sorting: redis returns elements in natural order (insertion order for lists,
+    # score order for sorted sets) and reverses only when DESC is given.
     r.rpush("mylist", "3", "1", "2", "5", "4")
     assert r.sort("mylist", by="nosort") == [b"3", b"1", b"2", b"5", b"4"]
     assert r.sort("mylist", by="nosort", desc=True) == [b"4", b"5", b"2", b"1", b"3"]

--- a/test/test_mixins/test_generic_commands.py
+++ b/test/test_mixins/test_generic_commands.py
@@ -230,6 +230,20 @@ def test_sort_with_by_and_get_option(r: ClientType):
     ]
 
 
+def test_sort_by_nosort_keeps_natural_order(r: ClientType):
+    # A `BY` pattern with no `*` disables sorting: redis returns elements in
+    # natural order (insertion order for lists, score order for sorted sets)
+    # and reverses only when DESC is given.
+    r.rpush("mylist", "3", "1", "2", "5", "4")
+    assert r.sort("mylist", by="nosort") == [b"3", b"1", b"2", b"5", b"4"]
+    assert r.sort("mylist", by="nosort", desc=True) == [b"4", b"5", b"2", b"1", b"3"]
+    # LIMIT must apply to the natural-order list, not a reversed one.
+    assert r.sort("mylist", by="nosort", start=1, num=2) == [b"1", b"2"]
+
+    r.zadd("myzset", {"a": 3, "c": 2, "b": 1})
+    assert r.sort("myzset", by="nosort") == [b"b", b"c", b"a"]
+
+
 def test_sort_with_hash(r: ClientType):
     r.rpush("foo", "middle")
     r.rpush("foo", "eldest")


### PR DESCRIPTION
### Problem

`SORT` (and `SORT_RO`) with a `BY` pattern that contains no `*` should disable sorting. In that case redis returns the elements in their **natural order** — insertion order for lists, score order for sorted sets — and reverses only when `DESC` is given.

fakeredis instead reversed the elements **unconditionally** in the `dontsort` branch, so it diverged from real redis for every default/`ASC` call (it only matched by accident under `DESC`). Because the `LIMIT` window is applied *after* this step, `LIMIT` results were wrong too.

Differential repro against a real redis 8.0 server:

```python
r.rpush("l", "3", "1", "2", "5", "4")
r.sort("l", by="nosort")              # real: [3,1,2,5,4]   fake: [4,5,2,1,3]  ❌
r.sort("l", by="nosort", start=1, num=2)  # real: [1,2]     fake: [5,2]        ❌
r.zadd("z", {"a":3,"c":2,"b":1})
r.sort("z", by="nosort")              # real: [b,c,a]       fake: [a,c,b]      ❌
```

### Fix

In the `dontsort` branch of both `sort` and `sort_ro` (`fakeredis/commands_mixins/generic_mixin.py`), only reverse when `desc` is set. Natural order is otherwise preserved, which also fixes the `LIMIT` window and the sorted-set case.

### Test

Added `test_sort_by_nosort_keeps_natural_order` to `test/test_mixins/test_generic_commands.py`, asserting natural order, the `DESC` reverse, the `LIMIT` window, and the sorted-set score order. It runs under the existing fake-vs-real fixture and passes against a real redis server. Verified red→green: without the fix the `FakeStrict2`/`FakeStrict3` variants fail with the reversed list; with it all variants pass, and the full `test_generic_commands.py` module is green.

I found this by differential testing fakeredis against a real redis server.

---
Disclosure: I use AI assistance (under my direction) to help with my contributions; I review and verify every change before submitting.
