### PR TITLE
fix: GETEX without options must not clear the key TTL

### DIFF
--- a/fakeredis/commands_mixins/string_mixin.py
+++ b/fakeredis/commands_mixins/string_mixin.py
@@ -284,10 +284,6 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
             raise SimpleError(msgs.INVALID_EXPIRE_MSG.format("getex"))
         if count_options > 1:
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
-
-        # Only alter the TTL when an expiry option was supplied. With no option
-        # GETEX behaves like GET and must leave any existing TTL untouched; only
-        # PERSIST (expire_time is None *with* an option) clears it.
         if count_options > 0:
             key.expireat = None if expire_time is None else int(expire_time)
         return key.get(None)

--- a/fakeredis/commands_mixins/string_mixin.py
+++ b/fakeredis/commands_mixins/string_mixin.py
@@ -285,7 +285,11 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
         if count_options > 1:
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
 
-        key.expireat = None if expire_time is None else int(expire_time)
+        # Only alter the TTL when an expiry option was supplied. With no option
+        # GETEX behaves like GET and must leave any existing TTL untouched; only
+        # PERSIST (expire_time is None *with* an option) clears it.
+        if count_options > 0:
+            key.expireat = None if expire_time is None else int(expire_time)
         return key.get(None)
 
     @command(fixed=(Key(bytes), Key(bytes)), repeat=(bytes,))

--- a/test/test_mixins/test_string_commands.py
+++ b/test/test_mixins/test_string_commands.py
@@ -555,6 +555,14 @@ def test_getex(r: ClientType):
     assert r.get("foo5") == b"val"
 
 
+def test_getex_no_option_keeps_ttl(r: ClientType):
+    # GETEX with no expiry option behaves like GET and must leave the TTL
+    # untouched; only PERSIST removes it.
+    r.set("foo", "val", ex=100)
+    assert r.getex("foo") == b"val"
+    assert r.ttl("foo") > 0
+
+
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 def test_lcs(r: ClientType):
     r.mset({"key1": "ohmytext", "key2": "mynewtext"})

--- a/test/test_mixins/test_string_commands.py
+++ b/test/test_mixins/test_string_commands.py
@@ -556,8 +556,7 @@ def test_getex(r: ClientType):
 
 
 def test_getex_no_option_keeps_ttl(r: ClientType):
-    # GETEX with no expiry option behaves like GET and must leave the TTL
-    # untouched; only PERSIST removes it.
+    # GETEX with no expiry option behaves like GET and must leave the TTL untouched; only PERSIST removes it.
     r.set("foo", "val", ex=100)
     assert r.getex("foo") == b"val"
     assert r.ttl("foo") > 0


### PR DESCRIPTION
### Bug

`GETEX key` with no options should behave like `GET` and leave any existing TTL untouched. Only the explicit expiry options (`EX`/`PX`/`EXAT`/`PEXAT`/`PERSIST`) may change it. fakeredis instead cleared the TTL on every option-less `GETEX`:

```python
r.set("foo", "bar", ex=100)
r.getex("foo")          # no options
r.ttl("foo")            # real Redis: 100 ; fakeredis: -1  (TTL wrongly removed)
```

### Root cause

In `string_mixin.py`, `getex` unconditionally ran `key.expireat = None if expire_time is None else int(expire_time)`. With no expiry option `expire_time` is `None`, so it cleared the TTL even though nothing asked it to. Only `PERSIST` should clear it.

### Fix

Set `key.expireat` only when an expiry option was actually supplied (`count_options > 0`). `PERSIST` still clears the TTL; every other option still applies as before.

A `test_getex_no_option_keeps_ttl` parity test is added (fails against fakeredis without the fix, passes against real Redis). Verified with the standard real-server test setup.

(Change drafted with AI assistance under my direction; I reproduced the divergence against real Redis and verified the test red/green myself.)
