### PR TITLE
fix: HEXPIRE/HPEXPIRE must reject a negative relative TTL

### DIFF
--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -122,6 +122,7 @@ TIMESERIES_DUPLICATE_POLICY_BLOCK = (
 )
 TIMESERIES_BAD_FILTER_EXPRESSION = "TSDB: failed parsing labels"
 HEXPIRE_NUMFIELDS_DIFFERENT = "The `numfields` parameter must match the number of arguments"
+INVALID_HASH_EXPIRE_TIME_MSG = "ERR invalid expire time, must be >= 0"
 
 MISSING_ACLFILE_CONFIG = "ERR This Redis instance is not configured to use an ACL file. You may want to specify users via the ACL SETUSER command and then issue a CONFIG REWRITE (assuming you have a Redis configuration file set) in order to store users in the Redis configuration."
 

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -197,11 +197,15 @@ class HashCommandsMixin(CommandsMixinBase):
 
     @command(name="HEXPIRE", fixed=(Key(Hash), Int), repeat=(bytes,))
     def hexpire(self, key: CommandItem, seconds: int, *args: bytes) -> List[int]:
+        if seconds < 0:
+            raise SimpleError(msgs.INVALID_HASH_EXPIRE_TIME_MSG)
         when_ms = current_time() + seconds * 1000
         return self._hexpire(key, when_ms, *args, command="hexpire")
 
     @command(name="HPEXPIRE", fixed=(Key(Hash), Int), repeat=(bytes,))
     def hpexpire(self, key: CommandItem, milliseconds: int, *args: bytes) -> List[int]:
+        if milliseconds < 0:
+            raise SimpleError(msgs.INVALID_HASH_EXPIRE_TIME_MSG)
         when_ms = current_time() + milliseconds
         return self._hexpire(key, when_ms, *args, command="hpexpire")
 

--- a/test/test_mixins/test_hash_expire_commands.py
+++ b/test/test_mixins/test_hash_expire_commands.py
@@ -2,6 +2,7 @@ import time
 from typing import Optional, Dict
 
 import pytest
+import redis
 
 from fakeredis._typing import ClientType
 from test import testtools
@@ -370,3 +371,17 @@ def test_hincrbyfloat_with_hash_key_expiration(r: ClientType):
     assert isinstance(res, list)
     assert len(res) == 1
     assert res[0] >= 0
+
+
+def test_hexpire_negative_ttl_raises(r: ClientType):
+    # HEXPIRE/HPEXPIRE take a relative time, so a negative value is an error
+    # (unlike the *AT variants, which accept a past absolute timestamp). The
+    # field must be left untouched, not deleted.
+    r.delete("redis-key")
+    r.hset("redis-key", mapping={"field1": "value1"})
+    with pytest.raises(redis.ResponseError, match="invalid expire time"):
+        r.hexpire("redis-key", -1, "field1")
+    with pytest.raises(redis.ResponseError, match="invalid expire time"):
+        r.hpexpire("redis-key", -1, "field1")
+    assert r.hget("redis-key", "field1") == b"value1"
+    assert r.httl("redis-key", "field1") == [-1]


### PR DESCRIPTION
### Summary

`HEXPIRE` and `HPEXPIRE` take a *relative* time in seconds/milliseconds, so a negative value is meaningless. Real Redis rejects it:

```
127.0.0.1:6379> HSET h a 1
127.0.0.1:6379> HEXPIRE h -1 FIELDS 1 a
(error) ERR invalid expire time, must be >= 0
```

fakeredis instead let the negative TTL fall through, which expired the field immediately and silently deleted it (returning `[2]`). That both diverges from Redis and destroys data on a call that should have been a no-op error.

### Fix

Validate the relative argument in `hexpire`/`hpexpire` and raise the same error before computing the expiry. The absolute `HEXPIREAT`/`HPEXPIREAT` variants are intentionally left unchanged, since they correctly accept a past timestamp (which does delete the field, matching Redis).

Added `test_hexpire_negative_ttl_raises`, which passes against both fakeredis and a real Redis 8.x; without the fix the fakeredis runs fail while the real-server runs pass.

I used an AI assistant to help investigate and implement this under my direction.
