### PR TITLE
fix: align Redis parity edge cases

### DIFF
--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -77,6 +77,7 @@ XGROUP_KEY_NOT_FOUND_MSG = (
     "ERR The XGROUP subcommand requires the key to exist."
     " Note that for CREATE you may want to use the MKSTREAM option to create an empty stream automatically."
 )
+GEO_INVALID_COORDINATE_MSG = "ERR invalid longitude,latitude pair {},{}"
 GEO_UNSUPPORTED_UNIT = "unsupported unit provided. please use M, KM, FT, MI"
 LPOS_RANK_CAN_NOT_BE_ZERO = (
     "RANK can't be zero: use 1 to start from the first match, 2 from the second ... "

--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -122,6 +122,7 @@ TIMESERIES_DUPLICATE_POLICY_BLOCK = (
 )
 TIMESERIES_BAD_FILTER_EXPRESSION = "TSDB: failed parsing labels"
 HEXPIRE_NUMFIELDS_DIFFERENT = "The `numfields` parameter must match the number of arguments"
+INVALID_HASH_EXPIRE_TIME_MSG = "ERR invalid expire time, must be >= 0"
 
 MISSING_ACLFILE_CONFIG = "ERR This Redis instance is not configured to use an ACL file. You may want to specify users via the ACL SETUSER command and then issue a CONFIG REWRITE (assuming you have a Redis configuration file set) in order to store users in the Redis configuration."
 

--- a/fakeredis/commands_mixins/bitmap_mixin.py
+++ b/fakeredis/commands_mixins/bitmap_mixin.py
@@ -227,6 +227,14 @@ class BitmapCommandsMixin(CommandsMixinBase):
             self.setbit(key, offset + i, bit)
         return new_value if value is None else ans
 
+    @staticmethod
+    def _bitfield_offset(offset: bytes, encoding: BitfieldEncoding) -> int:
+        # A leading '#' makes the offset a multiple of the type width, e.g.
+        # `GET u8 #1` reads the second u8 (bit offset 1 * 8 = 8).
+        if offset[:1] == b"#":
+            return BitOffset.decode(offset[1:]) * encoding.size
+        return BitOffset.decode(offset)
+
     @command(fixed=(Key(bytes),), repeat=(bytes,))
     def bitfield(self, key: CommandItem, *args: bytes) -> List[Optional[int]]:
         overflow = b"WRAP"
@@ -240,24 +248,26 @@ class BitmapCommandsMixin(CommandsMixinBase):
                 i += 2
             elif casematch(args[i], b"get") and i + 2 < len(args):
                 encoding = BitfieldEncoding(args[i + 1])
-                offset = BitOffset.decode(args[i + 2])
+                offset = self._bitfield_offset(args[i + 2], encoding)
                 results.append(self._bitfield_get(key, encoding, offset))
                 i += 3
             elif casematch(args[i], b"set") and i + 3 < len(args):
+                encoding = BitfieldEncoding(args[i + 1])
                 old_value = self._bitfield_set(
                     key=key,
-                    encoding=BitfieldEncoding(args[i + 1]),
-                    offset=BitOffset.decode(args[i + 2]),
+                    encoding=encoding,
+                    offset=self._bitfield_offset(args[i + 2], encoding),
                     value=Int.decode(args[i + 3]),
                     overflow=overflow,
                 )
                 results.append(old_value)
                 i += 4
             elif casematch(args[i], b"incrby") and i + 3 < len(args):
+                encoding = BitfieldEncoding(args[i + 1])
                 old_value = self._bitfield_set(
                     key=key,
-                    encoding=BitfieldEncoding(args[i + 1]),
-                    offset=BitOffset.decode(args[i + 2]),
+                    encoding=encoding,
+                    offset=self._bitfield_offset(args[i + 2], encoding),
                     incr=Int.decode(args[i + 3]),
                     overflow=overflow,
                 )

--- a/fakeredis/commands_mixins/geo_mixin.py
+++ b/fakeredis/commands_mixins/geo_mixin.py
@@ -11,6 +11,8 @@ from fakeredis.geo import distance, geo_encode, geo_decode
 from fakeredis.model import ZSet
 
 UNIT_TO_M = {"km": 0.001, "mi": 0.000621371, "ft": 3.28084, "m": 1}
+GEO_LONG_MIN, GEO_LONG_MAX = -180, 180
+GEO_LAT_MIN, GEO_LAT_MAX = -85.05112878, 85.05112878
 
 
 def translate_meters_to_unit(unit_arg: bytes) -> float:
@@ -132,6 +134,8 @@ class GeoCommandsMixin(CommandsMixinBase):
                 Float.decode(data[i + 1]),
                 data[i + 2],
             )
+            if not GEO_LONG_MIN <= long <= GEO_LONG_MAX or not GEO_LAT_MIN <= lat <= GEO_LAT_MAX:
+                raise SimpleError(msgs.GEO_INVALID_COORDINATE_MSG.format(f"{long:f}", f"{lat:f}"))
             if (name in zset and not xx) or (name not in zset and not nx):
                 if zset.add(name, geo_encode(lat, long, 10)):
                     changed_items += 1

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -197,11 +197,15 @@ class HashCommandsMixin(CommandsMixinBase):
 
     @command(name="HEXPIRE", fixed=(Key(Hash), Int), repeat=(bytes,))
     def hexpire(self, key: CommandItem, seconds: int, *args: bytes) -> List[int]:
+        if seconds < 0:
+            raise SimpleError(msgs.INVALID_HASH_EXPIRE_TIME_MSG)
         when_ms = current_time() + seconds * 1000
         return self._hexpire(key, when_ms, *args, command="hexpire")
 
     @command(name="HPEXPIRE", fixed=(Key(Hash), Int), repeat=(bytes,))
     def hpexpire(self, key: CommandItem, milliseconds: int, *args: bytes) -> List[int]:
+        if milliseconds < 0:
+            raise SimpleError(msgs.INVALID_HASH_EXPIRE_TIME_MSG)
         when_ms = current_time() + milliseconds
         return self._hexpire(key, when_ms, *args, command="hpexpire")
 

--- a/test/test_mixins/test_bitmap_commands.py
+++ b/test/test_mixins/test_bitmap_commands.py
@@ -431,3 +431,20 @@ def test_bitfield_set_wrong_arguments(r: ClientType):
         with pytest.raises(Exception) as ctx:
             raw_command(r, "bitfield", key, "set", encoding, 0, 0)
         assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
+
+
+def test_bitfield_hash_offset(r: ClientType):
+    # A '#' prefix multiplies the offset by the type width, so `#1` on a u8
+    # addresses the second byte (bit offset 8), not bit 1.
+    key = "key:bitfield:hash_offset"
+    r.set(key, b"\x00\x22\x00\x00")
+    assert raw_command(r, "bitfield", key, "get", "u8", "#1") == [0x22]
+    assert raw_command(r, "bitfield", key, "get", "u8", "#0", "get", "u8", "#1") == [0, 0x22]
+    assert raw_command(r, "bitfield", key, "set", "u8", "#0", 99) == [0]
+    assert raw_command(r, "bitfield", key, "get", "u8", "#0") == [99]
+    assert raw_command(r, "bitfield", key, "incrby", "u8", "#1", 1) == [0x23]
+    # Malformed '#' offsets are rejected like any other bad offset.
+    for bad in ("#", "#-1", "#abc"):
+        with pytest.raises(Exception) as ctx:
+            raw_command(r, "bitfield", key, "get", "u8", bad)
+        assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))

--- a/test/test_mixins/test_geo_commands.py
+++ b/test/test_mixins/test_geo_commands.py
@@ -40,6 +40,23 @@ def test_geoadd(r: ClientType):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
+@pytest.mark.parametrize(
+    "longitude,latitude",
+    [
+        ("-180.0001", "0"),
+        ("180.0001", "0"),
+        ("0", "-85.05112879"),
+        ("0", "85.05112879"),
+    ],
+)
+def test_geoadd_rejects_coordinates_outside_geohash_range(r: ClientType, longitude: str, latitude: str):
+    with pytest.raises(Exception) as ctx:
+        testtools.raw_command(r, "geoadd", "geo", longitude, latitude, "member")
+
+    assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
+    assert "invalid longitude,latitude pair" in str(ctx.value)
+
+
 def test_geoadd_xx(r: ClientType):
     values = (
         2.1909389952632,

--- a/test/test_mixins/test_hash_expire_commands.py
+++ b/test/test_mixins/test_hash_expire_commands.py
@@ -2,6 +2,7 @@ import time
 from typing import Optional, Dict
 
 import pytest
+import redis
 
 from fakeredis._typing import ClientType
 from test import testtools
@@ -370,3 +371,17 @@ def test_hincrbyfloat_with_hash_key_expiration(r: ClientType):
     assert isinstance(res, list)
     assert len(res) == 1
     assert res[0] >= 0
+
+
+def test_hexpire_negative_ttl_raises(r: ClientType):
+    # HEXPIRE/HPEXPIRE take a relative time, so a negative value is an error
+    # (unlike the *AT variants, which accept a past absolute timestamp). The
+    # field must be left untouched, not deleted.
+    r.delete("redis-key")
+    r.hset("redis-key", mapping={"field1": "value1"})
+    with pytest.raises(redis.ResponseError, match="invalid expire time"):
+        r.hexpire("redis-key", -1, "field1")
+    with pytest.raises(redis.ResponseError, match="invalid expire time"):
+        r.hpexpire("redis-key", -1, "field1")
+    assert r.hget("redis-key", "field1") == b"value1"
+    assert r.httl("redis-key", "field1") == [-1]


### PR DESCRIPTION
### Summary

Consolidates small Redis-parity fixes into one PR:

- `BITFIELD` now supports the documented `#` offset notation (`#N` means `N * type_width`) for `GET`, `SET`, and `INCRBY`.
- `HEXPIRE` and `HPEXPIRE` now reject negative relative TTLs instead of immediately deleting the field.
- `GEOADD` now rejects longitude/latitude values outside Redis' geohash range instead of accepting invalid coordinates.

### Verification

Each behavior was checked against a real Redis 8.8 server on `:6390` before implementation. The new tests pass against both fakeredis and the real-server variants.

Validated locally:

```bash
uv run pytest test/test_mixins/test_geo_commands.py::test_geoadd_rejects_coordinates_outside_geohash_range test/test_mixins/test_bitmap_commands.py::test_bitfield_hash_offset test/test_mixins/test_hash_expire_commands.py::test_hexpire_negative_ttl_raises
uv run pytest test/test_mixins/test_geo_commands.py test/test_mixins/test_bitmap_commands.py test/test_mixins/test_hash_expire_commands.py
uvx ruff check fakeredis/_msgs.py fakeredis/commands_mixins/geo_mixin.py fakeredis/commands_mixins/bitmap_mixin.py fakeredis/commands_mixins/hash_mixin.py test/test_mixins/test_geo_commands.py test/test_mixins/test_bitmap_commands.py test/test_mixins/test_hash_expire_commands.py
uvx ruff format --check fakeredis/_msgs.py fakeredis/commands_mixins/geo_mixin.py fakeredis/commands_mixins/bitmap_mixin.py fakeredis/commands_mixins/hash_mixin.py test/test_mixins/test_geo_commands.py test/test_mixins/test_bitmap_commands.py test/test_mixins/test_hash_expire_commands.py
uv run mypy fakeredis/commands_mixins/geo_mixin.py fakeredis/commands_mixins/bitmap_mixin.py fakeredis/commands_mixins/hash_mixin.py
```

I used an AI assistant to help investigate and implement this under my direction.
