### PR TITLE
feat:support multiple aggregators in TS.RANGE/TS.REVRANGE/TS.MRANGE/T…

### DIFF
--- a/fakeredis/commands_mixins/_mixin_base.py
+++ b/fakeredis/commands_mixins/_mixin_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fakeredis._typing import VersionType
+from fakeredis._typing import ServerType, VersionType
 
 if TYPE_CHECKING:
     from fakeredis._helpers import Database
@@ -19,4 +19,8 @@ class CommandsMixinBase:
 
     @property
     def version(self) -> VersionType:
+        raise NotImplementedError
+
+    @property
+    def server_type(self) -> ServerType:
         raise NotImplementedError

--- a/fakeredis/stack/_timeseries_mixin.py
+++ b/fakeredis/stack/_timeseries_mixin.py
@@ -340,12 +340,18 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
                 align = from_ts
             else:
                 align = int(align)
-        if aggregator is not None and aggregator not in AGGREGATORS:
-            raise SimpleError(msgs.TIMESERIES_BAD_AGGREGATION_TYPE)
         if aggregator is None:
             res = ts.range(from_ts, to_ts, value_min, value_max, count, filter_ts, reverse)
-        else:
-            res = ts.aggregate(
+            return [[x[0], x[1]] for x in res]
+
+        # Since redis 8.8, multiple comma-separated aggregators can be given in a single command.
+        aggregators: List[bytes] = aggregator.lower().split(b",")
+        if any(agg not in AGGREGATORS for agg in aggregators):
+            raise SimpleError(msgs.TIMESERIES_BAD_AGGREGATION_TYPE)
+        if len(aggregators) > 1 and (self.version < (8, 8) or self.server_type != "redis"):
+            raise SimpleError(msgs.TIMESERIES_BAD_AGGREGATION_TYPE)
+        aggregated = [
+            ts.aggregate(
                 from_ts,
                 to_ts,
                 latest,
@@ -354,14 +360,18 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
                 count,
                 filter_ts,
                 align,
-                aggregator,
+                agg,
                 bucket_duration,
                 bucket_timestamp,
                 empty,
                 reverse,
             )
-
-        result: List[List[Union[int, float]]] = [[x[0], x[1]] for x in res]
+            for agg in aggregators
+        ]
+        # Each bucket row is (timestamp, value-per-aggregator...); all aggregators share the same buckets.
+        result: List[List[Union[int, float]]] = [
+            [row[0]] + [aggregated[j][i][1] for j in range(len(aggregators))] for i, row in enumerate(aggregated[0])
+        ]
         return result
 
     @command(

--- a/test/test_stack/test_timeseries_multi_aggregators.py
+++ b/test/test_stack/test_timeseries_multi_aggregators.py
@@ -1,0 +1,75 @@
+"""Tests for multiple aggregators in a single TS.RANGE/TS.REVRANGE/TS.MRANGE/TS.MREVRANGE (redis 8.8)."""
+
+import pytest
+
+from fakeredis._typing import ClientType
+from test.testtools import raw_command, get_protocol_version
+
+timeseries_tests = pytest.importorskip("probables")
+
+pytestmark = []
+pytestmark.extend(
+    [
+        pytest.mark.supported_server_versions(min_redis_ver="8.7.2"),
+        pytest.mark.unsupported_server_types("dragonfly", "valkey"),
+    ]
+)
+
+
+@pytest.fixture
+def sample(r: ClientType) -> ClientType:
+    raw_command(r, "TS.CREATE", "ts1", "LABELS", "type", "temp")
+    raw_command(r, "TS.MADD", "ts1", 1000, 30, "ts1", 1010, 35, "ts1", 1020, 40, "ts1", 2000, 100, "ts1", 2010, 110)
+    return r
+
+
+def _values(res) -> list:
+    """Normalize (timestamp, value...) rows: RESP2 returns values as bulk strings, RESP3 as doubles."""
+    return [[row[0]] + [float(x) for x in row[1:]] for row in res]
+
+
+def test_ts_range_multiple_aggregators(sample: ClientType):
+    res = raw_command(sample, "TS.RANGE", "ts1", "-", "+", "AGGREGATION", "min,avg,max", 1000)
+    assert _values(res) == [[1000, 30.0, 35.0, 40.0], [2000, 100.0, 105.0, 110.0]]
+
+
+def test_ts_range_duplicate_aggregators(sample: ClientType):
+    res = raw_command(sample, "TS.RANGE", "ts1", "-", "+", "AGGREGATION", "min,min", 1000)
+    assert _values(res) == [[1000, 30.0, 30.0], [2000, 100.0, 100.0]]
+
+
+def test_ts_revrange_multiple_aggregators(sample: ClientType):
+    res = raw_command(sample, "TS.REVRANGE", "ts1", "-", "+", "AGGREGATION", "min,max", 1000)
+    assert _values(res) == [[2000, 100.0, 110.0], [1000, 30.0, 40.0]]
+
+
+def test_ts_range_multiple_aggregators_with_count(sample: ClientType):
+    res = raw_command(sample, "TS.RANGE", "ts1", "-", "+", "COUNT", 1, "AGGREGATION", "min,max", 1000)
+    assert _values(res) == [[1000, 30.0, 40.0]]
+
+
+def test_ts_mrange_multiple_aggregators(sample: ClientType):
+    res = raw_command(sample, "TS.MRANGE", "-", "+", "AGGREGATION", "min,max", 1000, "FILTER", "type=temp")
+    expected = [[1000, 30.0, 40.0], [2000, 100.0, 110.0]]
+    if get_protocol_version(sample) == 2:
+        assert len(res) == 1 and res[0][0] == b"ts1"
+        assert _values(res[0][-1]) == expected
+    else:
+        assert _values(res[b"ts1"][-1]) == expected
+
+
+def test_ts_mrevrange_multiple_aggregators(sample: ClientType):
+    res = raw_command(sample, "TS.MREVRANGE", "-", "+", "AGGREGATION", "min,max", 1000, "FILTER", "type=temp")
+    expected = [[2000, 100.0, 110.0], [1000, 30.0, 40.0]]
+    if get_protocol_version(sample) == 2:
+        assert _values(res[0][-1]) == expected
+    else:
+        assert _values(res[b"ts1"][-1]) == expected
+
+
+def test_ts_range_invalid_aggregator_in_list(sample: ClientType):
+    with pytest.raises(Exception, match="Unknown aggregation type"):
+        raw_command(sample, "TS.RANGE", "ts1", "-", "+", "AGGREGATION", "min,bogus", 1000)
+    # Whitespace between aggregators is not allowed
+    with pytest.raises(Exception, match="Unknown aggregation type"):
+        raw_command(sample, "TS.RANGE", "ts1", "-", "+", "AGGREGATION", "min, max", 1000)


### PR DESCRIPTION
…S.MREVRANGE (redis 8.8)

AGGREGATION accepts comma-separated aggregators (e.g. min,avg,max); each bucket row becomes (timestamp, value-per-aggregator...). Uppercase aggregator names are now accepted as well. Multiple aggregators are rejected with 'TSDB: Unknown aggregation type' when the server version is below 8.8, matching older servers.