### PR TITLE
feat:support hash field subkey notifications (redis 8.8)

### DIFF
--- a/fakeredis/_basefakesocket.py
+++ b/fakeredis/_basefakesocket.py
@@ -8,7 +8,7 @@ from typing import List, Any, Tuple, Optional, Callable, Union, Match, AnyStr, G
 
 import redis
 
-from fakeredis.model import ClientInfo, BaseModel
+from fakeredis.model import ClientInfo, BaseModel, Hash
 from . import _msgs as msgs
 from ._command_args_parsing import extract_args
 from ._commands import Int, Float, SUPPORTED_COMMANDS, COMMANDS_WITH_SUB, Signature, CommandItem
@@ -112,6 +112,8 @@ class BaseFakeSocket:
         # but set by aioredis module to prevent new commands being processed
         # while handling a blocking command.
         self._paused = False
+        # Subkey (hash field) events recorded by the currently running command: (event, key, subkeys)
+        self._subkey_events: List[Tuple[bytes, bytes, List[bytes]]] = []
         self._parser = self._parse_commands()
         self._parser.send(None)
         # Assigned elsewhere
@@ -277,6 +279,7 @@ class BaseFakeSocket:
         self, func: Optional[Callable[[Any], Any]], sig: Signature, args: List[Any], from_script: bool
     ) -> Any:
         command_items: List[CommandItem] = []
+        self._subkey_events = []
         try:
             ret = sig.apply(args, self._db, self.version)
             if from_script and msgs.FLAG_NO_SCRIPT in sig.flags:
@@ -299,7 +302,22 @@ class BaseFakeSocket:
         for command_item in command_items:
             command_item.writeback(remove_empty_val=msgs.FLAG_LEAVE_EMPTY_VAL not in sig.flags)
         self._keyspace_notifications(command_items, sig.name.encode())
+        self._subkey_notifications(command_items)
         return result
+
+    def _publish_to_channel(
+        self, channel: bytes, message: bytes, pattern_regex: Dict[bytes, "re.Pattern[bytes]"]
+    ) -> None:
+        msg = [b"message", channel, message]
+        subs: Iterable[Any] = self._server.subscribers.get(channel, set())
+        for sock in subs:
+            sock.put_response(msg)
+
+        for pattern, regex in pattern_regex.items():
+            if regex.match(channel):
+                pmsg = [b"pmessage", pattern, channel, message]
+                for sock in self._server.psubscribers[pattern]:
+                    sock.put_response(pmsg)
 
     def _keyspace_notifications(self, command_items: List[CommandItem], event: bytes) -> None:
         """Send keyspace notifications"""
@@ -315,19 +333,62 @@ class BaseFakeSocket:
                 keyspace_channel = keyspace_channel_prefix + command_item.key
 
                 for channel, message in [(keyspace_channel, event), (keyevent_channel, command_item.key)]:
-                    msg = [b"message", channel, message]
-                    subs: Iterable[Any] = self._server.subscribers.get(channel, set())
-                    for sock in subs:
-                        sock.put_response(msg)
-
-                    for pattern, regex in pattern_regex.items():
-                        if regex.match(channel):
-                            pmsg = [b"pmessage", pattern, channel, message]
-                            for sock in self._server.psubscribers[pattern]:
-                                sock.put_response(pmsg)
+                    self._publish_to_channel(channel, message, pattern_regex)
             except Exception as e:
                 LOGGER.error(
                     f"Error sending keyspace notification for event `{event.decode()}` on key {command_item.key.decode()}: {e}"
+                )
+
+    def add_subkey_event(self, event: bytes, key: bytes, subkeys: Sequence[bytes]) -> None:
+        """Record a subkey (e.g. hash field) event, to be published once the current command finishes."""
+        if len(subkeys) > 0:
+            self._subkey_events.append((event, key, list(subkeys)))
+
+    def _subkey_notifications(self, command_items: List[CommandItem]) -> None:
+        """Send subkey notifications (added in redis 8.8), currently emitted for hash fields only.
+
+        Unlike key-level notifications above, these follow the `notify-keyspace-events` config:
+        the `h` class flag must be set, and each of the S/T/I/V flags enables one channel type.
+        """
+        events, self._subkey_events = self._subkey_events, []
+        for command_item in command_items:
+            if isinstance(command_item.value, Hash):
+                expired_fields = command_item.value.take_expired_fields()
+                if expired_fields:
+                    events.insert(0, (b"hexpired", command_item.key, expired_fields))
+        if not events or self.version < (8, 8) or self._server.server_type != "redis":
+            return
+        config_flags = self._server.config.get(b"notify-keyspace-events", b"")
+        if b"h" not in config_flags and b"A" not in config_flags:
+            return
+        if not any(flag in config_flags for flag in (b"S", b"T", b"I", b"V")):
+            return
+        pattern_regex: Dict[bytes, re.Pattern[bytes]] = {
+            pattern: compile_pattern(pattern) for pattern in self._server.psubscribers
+        }
+        db_num = str(self._db_num).encode()
+        for event, key, subkeys in events:
+            try:
+                subkeys_payload = b",".join(b"%d:%s" % (len(subkey), subkey) for subkey in subkeys)
+                # Events containing `|` are skipped for the channels using `|` as a delimiter,
+                # and keys containing `\n` for the channel using `\n` as a delimiter.
+                if b"S" in config_flags and b"|" not in event:
+                    channel = b"__subkeyspace@%s__:%s" % (db_num, key)
+                    self._publish_to_channel(channel, event + b"|" + subkeys_payload, pattern_regex)
+                if b"T" in config_flags:
+                    channel = b"__subkeyevent@%s__:%s" % (db_num, event)
+                    message = b"%d:%s|%s" % (len(key), key, subkeys_payload)
+                    self._publish_to_channel(channel, message, pattern_regex)
+                if b"I" in config_flags and b"\n" not in key:
+                    for subkey in subkeys:
+                        channel = b"__subkeyspaceitem@%s__:%s\n%s" % (db_num, key, subkey)
+                        self._publish_to_channel(channel, event, pattern_regex)
+                if b"V" in config_flags and b"|" not in event:
+                    channel = b"__subkeyspaceevent@%s__:%s|%s" % (db_num, event, key)
+                    self._publish_to_channel(channel, subkeys_payload, pattern_regex)
+            except Exception as e:
+                LOGGER.error(
+                    f"Error sending subkey notification for event `{event.decode()}` on key {key.decode()}: {e}"
                 )
 
     def _decode_error(self, error: SimpleError) -> ResponseErrorType:

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -21,6 +21,7 @@ class HashCommandsMixin(CommandsMixinBase):
     ]
     _encodefloat: Callable[[float, bool], bytes]
     _scan: Callable[[Sequence[bytes], int, bytes], List[Union[bytes, List[bytes]]]]
+    add_subkey_event: Callable[[bytes, bytes, Sequence[bytes]], None]
 
     def _hset(self, key: CommandItem, *args: bytes) -> int:
         h = key.value
@@ -29,18 +30,20 @@ class HashCommandsMixin(CommandsMixinBase):
         created = len(h) - previous_keys_count
 
         key.updated()
+        self.add_subkey_event(b"hset", key.key, args[::2])
         return created
 
     @command((Key(Hash), bytes), (bytes,))
     def hdel(self, key: CommandItem, *fields: bytes) -> int:
         h = key.value
-        rem = 0
+        deleted = []
         for field in fields:
             if field in h:
                 del h[field]
                 key.updated()
-                rem += 1
-        return rem
+                deleted.append(field)
+        self.add_subkey_event(b"hdel", key.key, deleted)
+        return len(deleted)
 
     @command((Key(Hash), bytes))
     def hexists(self, key: CommandItem, field: bytes) -> int:
@@ -62,6 +65,7 @@ class HashCommandsMixin(CommandsMixinBase):
         c = field_value + amount
         key.value.update({field: self._encodeint(c)}, clear_expiration=False)
         key.updated()
+        self.add_subkey_event(b"hincrby", key.key, (field,))
         return c
 
     @command((Key(Hash), bytes, bytes))
@@ -72,6 +76,7 @@ class HashCommandsMixin(CommandsMixinBase):
         encoded = self._encodefloat(c, True)
         key.value.update({field: encoded}, clear_expiration=False)
         key.updated()
+        self.add_subkey_event(b"hincrbyfloat", key.key, (field,))
         return encoded
 
     @command((Key(Hash),))
@@ -162,6 +167,8 @@ class HashCommandsMixin(CommandsMixinBase):
             return [-2] * len(fields)
         # process command
         res = []
+        expired_fields: List[bytes] = []
+        deleted_fields: List[bytes] = []
         for field in fields:
             if field not in hash_val:
                 res.append(-2)
@@ -175,7 +182,11 @@ class HashCommandsMixin(CommandsMixinBase):
             ):
                 res.append(0)
                 continue
-            res.append(hash_val.set_key_expireat(field, when_ms))
+            field_res = hash_val.set_key_expireat(field, when_ms)
+            (expired_fields if field_res == 1 else deleted_fields).append(field)
+            res.append(field_res)
+        self.add_subkey_event(b"hexpire", key.key, expired_fields)
+        self.add_subkey_event(b"hdel", key.key, deleted_fields)
         return res
 
     def _get_expireat(self, command: bytes, key: CommandItem, *args: bytes) -> List[int]:
@@ -223,14 +234,17 @@ class HashCommandsMixin(CommandsMixinBase):
         fields = _get_fields(args, command="hpersist")
         hash_val: Hash = key.value
         res = []
+        persisted_fields = []
         for field in fields:
             if field not in hash_val:
                 res.append(-2)
                 continue
             if hash_val.clear_key_expireat(field):
+                persisted_fields.append(field)
                 res.append(1)
             else:
                 res.append(-1)
+        self.add_subkey_event(b"hpersist", key.key, persisted_fields)
         return res
 
     @command(
@@ -262,6 +276,10 @@ class HashCommandsMixin(CommandsMixinBase):
         fields = _get_fields(args, command="hgetdel")
         hash_val: Hash = key.value
         res = [hash_val.pop(field) for field in fields]
+        deleted_fields = [field for field, value in zip(fields, res) if value is not None]
+        if deleted_fields:
+            key.updated()
+        self.add_subkey_event(b"hdel", key.key, deleted_fields)
         return res
 
     @command(name="HGETEX", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
@@ -279,12 +297,22 @@ class HashCommandsMixin(CommandsMixinBase):
 
         when_ms = _get_when_ms(ex, px, exat, pxat)
         res = []
+        persisted_fields: List[bytes] = []
+        expired_fields: List[bytes] = []
+        deleted_fields: List[bytes] = []
         for field in fields:
             res.append(hash_val.get(field))
+            if field not in hash_val:
+                continue
             if persist:
-                hash_val.clear_key_expireat(field)
+                if hash_val.clear_key_expireat(field):
+                    persisted_fields.append(field)
             elif when_ms is not None:
-                hash_val.set_key_expireat(field, when_ms)
+                field_res = hash_val.set_key_expireat(field, when_ms)
+                (expired_fields if field_res == 1 else deleted_fields).append(field)
+        self.add_subkey_event(b"hexpire", key.key, expired_fields)
+        self.add_subkey_event(b"hpersist", key.key, persisted_fields)
+        self.add_subkey_event(b"hdel", key.key, deleted_fields)
         return res
 
     @command(name="HSETEX", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
@@ -309,13 +337,21 @@ class HashCommandsMixin(CommandsMixinBase):
         if fnx and len(field_keys - hash_val.getall().keys()) < len(field_keys):
             return 0
         res = 0
+        set_fields: List[bytes] = []
+        expired_fields: List[bytes] = []
+        deleted_fields: List[bytes] = []
         for i in range(0, len(field_vals), 2):
             field, value = field_vals[i], field_vals[i + 1]
             hash_val[field] = value
             res = 1
+            set_fields.append(field)
             if not keepttl and when_ms is not None:
-                hash_val.set_key_expireat(field, when_ms)
+                field_res = hash_val.set_key_expireat(field, when_ms)
+                (expired_fields if field_res == 1 else deleted_fields).append(field)
         key.updated()
+        self.add_subkey_event(b"hset", key.key, set_fields)
+        self.add_subkey_event(b"hexpire", key.key, expired_fields)
+        self.add_subkey_event(b"hdel", key.key, deleted_fields)
         return res
 
 

--- a/fakeredis/model/_hash.py
+++ b/fakeredis/model/_hash.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Iterator, Tuple, Optional, Any, Dict, AnyStr
+from typing import Iterable, Iterator, List, Tuple, Optional, Any, Dict, AnyStr
 
 from fakeredis import _msgs as msgs
 from fakeredis._helpers import current_time, asbytes
@@ -13,6 +13,8 @@ class Hash(BaseModel):
         super().__init__(*args, **kwargs)
         self._expirations: Dict[bytes, int] = {}
         self._values: Dict[bytes, bytes] = {}
+        # Fields that expired lazily, pending an `hexpired` subkey notification.
+        self._expired_fields: List[bytes] = []
 
     def _expire_keys(self) -> None:
         now = current_time()
@@ -20,6 +22,12 @@ class Hash(BaseModel):
         for k in expired:
             del self._values[k]
             del self._expirations[k]
+        self._expired_fields.extend(expired)
+
+    def take_expired_fields(self) -> List[bytes]:
+        """Return fields that expired since the last call, clearing the buffer."""
+        res, self._expired_fields = self._expired_fields, []
+        return res
 
     def set_key_expireat(self, key: AnyStr, when_ms: int) -> int:
         now = current_time()

--- a/test/test_subkey_notifications.py
+++ b/test/test_subkey_notifications.py
@@ -1,0 +1,169 @@
+"""Tests for hash-field subkey notifications (redis 8.8).
+
+Subkey notifications are controlled by the `notify-keyspace-events` config: the `h` class flag
+enables hash-command events, and each of the S/T/I/V flags enables one subkey channel type.
+"""
+
+import time
+from typing import List, Tuple
+
+import pytest
+
+from fakeredis._typing import ClientType
+
+pytestmark = []
+pytestmark.extend(
+    [
+        pytest.mark.supported_server_versions(min_redis_ver="8.7.2"),
+        pytest.mark.unsupported_server_types("dragonfly", "valkey"),
+    ]
+)
+
+
+def collect_messages(pubsub, timeout=1.0) -> List[Tuple[bytes, bytes]]:
+    """Collect (channel, data) of pmessages until no message arrives within a short poll window."""
+    deadline = time.time() + timeout
+    messages = []
+    while time.time() < deadline:
+        message = pubsub.get_message(ignore_subscribe_messages=True)
+        if message is None:
+            if messages:
+                break
+            time.sleep(0.01)
+            continue
+        if message["type"] == "pmessage":
+            messages.append((message["channel"], message["data"]))
+    return messages
+
+
+@pytest.fixture
+def pubsub(r: ClientType):
+    r.config_set("notify-keyspace-events", "STIVh")
+    p = r.pubsub()
+    p.psubscribe("__subkey*")
+    message = p.get_message(timeout=1.0)
+    assert message["type"] == "psubscribe"
+    yield p
+    r.config_set("notify-keyspace-events", "")
+    p.close()
+
+
+def test_subkey_hset(r: ClientType, pubsub):
+    r.hset("hash", mapping={"field1": "v1", "field2": "v2"})
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hset|6:field1,6:field2") in messages
+    assert (b"__subkeyevent@2__:hset", b"4:hash|6:field1,6:field2") in messages
+    assert (b"__subkeyspaceitem@2__:hash\nfield1", b"hset") in messages
+    assert (b"__subkeyspaceitem@2__:hash\nfield2", b"hset") in messages
+    assert (b"__subkeyspaceevent@2__:hset|hash", b"6:field1,6:field2") in messages
+
+
+def test_subkey_hdel(r: ClientType, pubsub):
+    r.hset("hash", mapping={"field1": "v1", "field2": "v2"})
+    collect_messages(pubsub)
+    r.hdel("hash", "field1", "missing")
+    messages = collect_messages(pubsub)
+    # Only actually-deleted fields are included
+    assert (b"__subkeyspace@2__:hash", b"hdel|6:field1") in messages
+    assert (b"__subkeyspaceevent@2__:hdel|hash", b"6:field1") in messages
+
+
+def test_subkey_hsetnx(r: ClientType, pubsub):
+    r.hsetnx("hash", "field", "v1")
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hset|5:field") in messages
+    # HSETNX on an existing field does not fire an event
+    r.hsetnx("hash", "field", "v2")
+    assert collect_messages(pubsub, timeout=0.3) == []
+
+
+def test_subkey_hincrby(r: ClientType, pubsub):
+    r.hincrby("hash", "counter", 5)
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hincrby|7:counter") in messages
+    r.hincrbyfloat("hash", "fcounter", 1.5)
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hincrbyfloat|8:fcounter") in messages
+
+
+def test_subkey_hexpire_and_hpersist(r: ClientType, pubsub):
+    r.hset("hash", mapping={"field1": "v1", "field2": "v2"})
+    collect_messages(pubsub)
+    r.hexpire("hash", 100, "field1", "field2")
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hexpire|6:field1,6:field2") in messages
+    r.hpersist("hash", "field1")
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hpersist|6:field1") in messages
+    # HPERSIST on a field without a TTL does not fire an event
+    r.hpersist("hash", "field1")
+    assert collect_messages(pubsub, timeout=0.3) == []
+
+
+def test_subkey_hexpire_past_deletes(r: ClientType, pubsub):
+    r.hset("hash", mapping={"field1": "v1", "field2": "v2"})
+    collect_messages(pubsub)
+    # Expiration in the past deletes the field immediately, firing hdel
+    r.hexpire("hash", 0, "field1")
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hdel|6:field1") in messages
+
+
+def test_subkey_hexpired(r: ClientType, pubsub):
+    r.hset("hash", "field", "v1")
+    r.hpexpire("hash", 30, "field")
+    collect_messages(pubsub)
+    time.sleep(0.15)
+    r.hget("hash", "field")
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hexpired|5:field") in messages
+    assert (b"__subkeyspaceitem@2__:hash\nfield", b"hexpired") in messages
+
+
+def test_subkey_hsetex(r: ClientType, pubsub):
+    r.execute_command("HSETEX", "hash", "EX", 100, "FIELDS", 1, "field", "v1")
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hset|5:field") in messages
+    assert (b"__subkeyspace@2__:hash", b"hexpire|5:field") in messages
+
+
+def test_subkey_hgetdel(r: ClientType, pubsub):
+    r.hset("hash", "field", "v1")
+    collect_messages(pubsub)
+    r.execute_command("HGETDEL", "hash", "FIELDS", 1, "field")
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hdel|5:field") in messages
+
+
+def test_subkey_binary_safe_payload(r: ClientType, pubsub):
+    r.hset("hash", mapping={b"fi|eld": b"v"})
+    messages = collect_messages(pubsub)
+    assert (b"__subkeyspace@2__:hash", b"hset|6:fi|eld") in messages
+
+
+def test_subkey_single_channel_flag(r: ClientType):
+    # Only the subkeyspace channel is enabled
+    r.config_set("notify-keyspace-events", "Sh")
+    p = r.pubsub()
+    p.psubscribe("__subkey*")
+    assert p.get_message(timeout=1.0)["type"] == "psubscribe"
+    r.hset("hash", "field", "v1")
+    messages = collect_messages(p)
+    assert messages == [(b"__subkeyspace@2__:hash", b"hset|5:field")]
+    r.config_set("notify-keyspace-events", "")
+    p.close()
+
+
+def test_subkey_disabled_without_flags(r: ClientType):
+    r.config_set("notify-keyspace-events", "")
+    p = r.pubsub()
+    p.psubscribe("__subkey*")
+    assert p.get_message(timeout=1.0)["type"] == "psubscribe"
+    r.hset("hash", "field", "v1")
+    assert collect_messages(p, timeout=0.3) == []
+    # The channel flags alone are not enough: the hash class flag `h` is required as well
+    r.config_set("notify-keyspace-events", "STIV")
+    r.hset("hash", "field2", "v2")
+    assert collect_messages(p, timeout=0.3) == []
+    r.config_set("notify-keyspace-events", "")
+    p.close()


### PR DESCRIPTION
Adds the four subkey notification channels (__subkeyspace@<db>__:<key>, __subkeyevent@<db>__:<event>, __subkeyspaceitem@<db>__:<key>\n<subkey>, __subkeyspaceevent@<db>__:<event>|<key>) with length-prefixed subkey payloads. Emission follows the notify-keyspace-events config: the 'h' class flag is required and each of S/T/I/V enables one channel type.

Hash commands emit hset/hdel/hincrby/hincrbyfloat/hexpire/hpersist events for the affected fields (expiration in the past emits hdel), and lazily-expired fields emit hexpired. Only published when the server version is 8.8+ and the server type is redis.