### PR TITLE
test:skip subkey notification tests on redis-py below 5

### DIFF
--- a/test/test_subkey_notifications.py
+++ b/test/test_subkey_notifications.py
@@ -10,12 +10,15 @@ from typing import List, Tuple
 import pytest
 
 from fakeredis._typing import ClientType
+from test import testtools
 
 pytestmark = []
 pytestmark.extend(
     [
         pytest.mark.supported_server_versions(min_redis_ver="8.7.2"),
         pytest.mark.unsupported_server_types("dragonfly", "valkey"),
+        # The hash field expiration helpers used here were added in redis-py 5
+        testtools.run_test_if_redispy_ver("gte", "5"),
     ]
 )
 


### PR DESCRIPTION
The tests use the hash field expiration helpers (hexpire/hpexpire/ hpersist), which redis-py only grew in 5.0, so they raise AttributeError on redis-py 4.x. Gate them the same way test_hash_expire_commands.py already does.