### PR TITLE
Modernize typing for Ruff 0.16 defaults, support Python 3.8

### DIFF
--- a/fakeredis/__init__.py
+++ b/fakeredis/__init__.py
@@ -1,8 +1,10 @@
 from . import _typing
-from ._connection import FakeRedis, FakeStrictRedis, FakeRedisConnection, FakeConnection
+from ._connection import FakeConnection, FakeRedis, FakeRedisConnection, FakeStrictRedis
 from ._server import FakeServer
 from ._tcp_server import TcpFakeServer
-from .aioredis import FakeRedis as FakeAsyncRedis, FakeAsyncRedisConnection, FakeConnection as FakeAsyncConnection
+from .aioredis import FakeAsyncRedisConnection
+from .aioredis import FakeConnection as FakeAsyncConnection
+from .aioredis import FakeRedis as FakeAsyncRedis
 
 __version__ = _typing.lib_version
 __author__ = "Daniel Moran"
@@ -13,26 +15,27 @@ __url__ = "https://github.com/cunla/fakeredis-py"
 __bugtrack_url__ = "https://github.com/cunla/fakeredis-py/issues"
 
 __all__ = [
-    "FakeServer",
-    "FakeRedis",
-    "FakeStrictRedis",
-    "FakeRedisConnection",
-    "FakeConnection",
+    "FakeAsyncConnection",
     "FakeAsyncRedis",
     "FakeAsyncRedisConnection",
-    "FakeAsyncConnection",
+    "FakeConnection",
+    "FakeRedis",
+    "FakeRedisConnection",
+    "FakeServer",
+    "FakeStrictRedis",
     "TcpFakeServer",
 ]
 
 try:
     import valkey  # noqa: F401
-    from ._valkey import FakeValkey, FakeAsyncValkey, FakeStrictValkey  # noqa: F401
+
+    from ._valkey import FakeAsyncValkey, FakeStrictValkey, FakeValkey  # noqa: F401
 
     __all__.extend(
         [
-            "FakeValkey",
             "FakeAsyncValkey",
             "FakeStrictValkey",
+            "FakeValkey",
         ]
     )
 except ImportError:

--- a/fakeredis/_basefakesocket.py
+++ b/fakeredis/_basefakesocket.py
@@ -1,28 +1,33 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import queue
 import re
 import time
 import weakref
-from typing import List, Any, Tuple, Optional, Callable, Union, Match, AnyStr, Generator, Sequence, Type, Dict, Iterable
+from collections.abc import Generator, Iterable, Sequence
+from re import Match
+from typing import Any, AnyStr, Callable, ClassVar
 
 import redis
 
-from fakeredis.model import ClientInfo, BaseModel, Hash
+from fakeredis.model import BaseModel, ClientInfo, Hash
+
 from . import _msgs as msgs
 from ._command_args_parsing import extract_args
-from ._commands import Int, Float, SUPPORTED_COMMANDS, COMMANDS_WITH_SUB, Signature, CommandItem
+from ._commands import COMMANDS_WITH_SUB, SUPPORTED_COMMANDS, CommandItem, Float, Int, Signature
 from ._helpers import (
-    SimpleError,
-    valid_response_type,
-    SimpleString,
+    QUEUED,
     NoResponse,
+    SimpleError,
+    SimpleString,
     casematch,
     compile_pattern,
-    QUEUED,
     decode_command_bytes,
+    valid_response_type,
 )
-from ._typing import ResponseErrorType, VersionType, ServerType
+from ._typing import ResponseErrorType, ServerType, VersionType
 
 LOGGER = logging.getLogger("fakeredis")
 
@@ -40,7 +45,7 @@ def _convert_to_resp2(val: Any) -> Any:
     return val
 
 
-def _extract_command(fields: List[bytes]) -> Tuple[Any, List[Any]]:
+def _extract_command(fields: list[bytes]) -> tuple[Any, list[Any]]:
     """Extracts the command and command arguments from a list of `bytes` fields.
 
     :param fields: A list of `bytes` fields containing the command and command arguments.
@@ -79,7 +84,7 @@ def _get_next_file_no() -> int:
 
 class BaseFakeSocket:
     _clear_watches: Callable[[], None]
-    ACCEPTED_COMMANDS_WHILE_PUBSUB = {
+    ACCEPTED_COMMANDS_WHILE_PUBSUB: ClassVar[set[str]] = {
         "ping",
         "subscribe",
         "unsubscribe",
@@ -93,14 +98,14 @@ class BaseFakeSocket:
 
     def __init__(
         self,
-        server: "FakeServer",  # type: ignore # noqa: F821
+        server: FakeServer,  # type: ignore # noqa: F821
         db: int,
-        client_class: Type,  # type: ignore
+        client_class: type,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         info = kwargs.pop("client_info", {})
-        super(BaseFakeSocket, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         from fakeredis import FakeServer
 
         self._server: FakeServer = server
@@ -108,7 +113,7 @@ class BaseFakeSocket:
         self._db_num = db
         self._db = server.dbs[self._db_num]
         self._client_class = client_class
-        self.responses: Optional[queue.Queue[bytes]] = queue.Queue()
+        self.responses: queue.Queue[bytes] | None = queue.Queue()
         # Prevents parser from processing commands. Not used in this module,
         # but set by aioredis module to prevent new commands being processed
         # while handling a blocking command.
@@ -126,20 +131,20 @@ class BaseFakeSocket:
         # Set while parked in _blocking, so CLIENT UNBLOCK can tell whether this
         # client is blocked and, if so, how it should be woken.
         self._blocked = False
-        self._unblock_reason: Optional[bytes] = None
+        self._unblock_reason: bytes | None = None
         # Subkey (hash field) events recorded by the currently running command: (event, key, subkeys)
-        self._subkey_events: List[Tuple[bytes, bytes, List[bytes]]] = []
+        self._subkey_events: list[tuple[bytes, bytes, list[bytes]]] = []
         self._parser = self._parse_commands()
         self._parser.send(None)
         # Assigned elsewhere
-        self._transaction: Optional[List[Any]]
+        self._transaction: list[Any] | None
         self._in_transaction: bool
         self._pubsub: int
         self._transaction_failed: bool
         info.update(
-            dict(
-                id=self._server.get_next_client_id(),
-            )
+            {
+                "id": self._server.get_next_client_id(),
+            }
         )
         self._client_info = ClientInfo(**info)
         self._server.sockets.append(self)
@@ -181,7 +186,7 @@ class BaseFakeSocket:
     def fileno(self) -> int:
         return self._fileno
 
-    def _cleanup(self, server: Any) -> None:  # noqa: F821
+    def _cleanup(self, server: Any) -> None:
         """Remove all the references to `self` from `server`.
 
         This is called with the server lock held, but it may be some time after
@@ -223,7 +228,7 @@ class BaseFakeSocket:
         self.responses = None
 
     @staticmethod
-    def _extract_line(buf: bytes) -> Tuple[bytes, bytes]:
+    def _extract_line(buf: bytes) -> tuple[bytes, bytes]:
         pos = buf.find(b"\n") + 1
         if pos <= 0:
             raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format(buf.decode().strip()))
@@ -264,7 +269,7 @@ class BaseFakeSocket:
                 buf = buf[length + 2 :]  # +2 to skip the CRLF
             self._process_command(fields)
 
-    def _process_command(self, fields: List[bytes]) -> None:
+    def _process_command(self, fields: list[bytes]) -> None:
         if not fields:
             return
         result: Any
@@ -314,9 +319,9 @@ class BaseFakeSocket:
         self.put_response(result)
 
     def _run_command(
-        self, func: Optional[Callable[[Any], Any]], sig: Signature, args: List[Any], from_script: bool
+        self, func: Callable[[Any], Any] | None, sig: Signature, args: list[Any], from_script: bool
     ) -> Any:
-        command_items: List[CommandItem] = []
+        command_items: list[CommandItem] = []
         self._subkey_events = []
         try:
             ret = sig.apply(args, self._db, self.version)
@@ -344,7 +349,7 @@ class BaseFakeSocket:
         return result
 
     def _publish_to_channel(
-        self, channel: bytes, message: bytes, pattern_regex: Dict[bytes, "re.Pattern[bytes]"]
+        self, channel: bytes, message: bytes, pattern_regex: dict[bytes, re.Pattern[bytes]]
     ) -> None:
         msg = [b"message", channel, message]
         subs: Iterable[Any] = self._server.subscribers.get(channel, set())
@@ -357,9 +362,9 @@ class BaseFakeSocket:
                 for sock in self._server.psubscribers[pattern]:
                     sock.put_response(pmsg)
 
-    def _keyspace_notifications(self, command_items: List[CommandItem], event: bytes) -> None:
+    def _keyspace_notifications(self, command_items: list[CommandItem], event: bytes) -> None:
         """Send keyspace notifications"""
-        pattern_regex: Dict[bytes, re.Pattern[bytes]] = {
+        pattern_regex: dict[bytes, re.Pattern[bytes]] = {
             pattern: compile_pattern(pattern) for pattern in self._server.psubscribers
         }
         keyspace_channel_prefix: bytes = f"__keyspace@{self._db_num}__:".encode()
@@ -382,7 +387,7 @@ class BaseFakeSocket:
         if len(subkeys) > 0:
             self._subkey_events.append((event, key, list(subkeys)))
 
-    def _subkey_notifications(self, command_items: List[CommandItem]) -> None:
+    def _subkey_notifications(self, command_items: list[CommandItem]) -> None:
         """Send subkey notifications (added in redis 8.8), currently emitted for hash fields only.
 
         Unlike key-level notifications above, these follow the `notify-keyspace-events` config:
@@ -401,7 +406,7 @@ class BaseFakeSocket:
             return
         if not any(flag in config_flags for flag in (b"S", b"T", b"I", b"V")):
             return
-        pattern_regex: Dict[bytes, re.Pattern[bytes]] = {
+        pattern_regex: dict[bytes, re.Pattern[bytes]] = {
             pattern: compile_pattern(pattern) for pattern in self._server.psubscribers
         }
         db_num = str(self._db_num).encode()
@@ -450,7 +455,7 @@ class BaseFakeSocket:
         else:
             return result
 
-    def _blocking(self, timeout: Optional[Union[float, int]], func: Callable[[bool], Any]) -> Any:
+    def _blocking(self, timeout: float | None, func: Callable[[bool], Any]) -> Any:
         """Run a function until it succeeds or timeout is reached.
 
         The timeout is in seconds, and 0 means infinite. The function
@@ -489,7 +494,7 @@ class BaseFakeSocket:
         if reason == b"error":
             raise SimpleError(msgs.UNBLOCKED_MSG)
 
-    def _name_to_func(self, cmd_name: str) -> Tuple[Optional[Callable[[Any], Any]], Signature]:
+    def _name_to_func(self, cmd_name: str) -> tuple[Callable[[Any], Any] | None, Signature]:
         """Get the signature and the method from the command name."""
         if cmd_name not in SUPPORTED_COMMANDS:
             # redis remaps \r or \n in an error to ' ' to make it legal protocol
@@ -510,7 +515,7 @@ class BaseFakeSocket:
             data = data.encode("ascii")  # type: ignore
         self._parser.send(data)
 
-    def _scan(self, keys: Sequence[bytes], cursor: int, *args: bytes) -> List[Union[bytes, List[bytes]]]:
+    def _scan(self, keys: Sequence[bytes], cursor: int, *args: bytes) -> list[bytes | list[bytes]]:
         """This is the basis of most of the ``scan`` methods.
 
         This implementation is KNOWN to be un-performant, as it requires grabbing the full set of keys over which
@@ -554,7 +559,7 @@ class BaseFakeSocket:
 
         regex = compile_pattern(pattern) if pattern is not None else None
 
-        def match_key(key: bytes) -> Union[bool, Match[bytes], None]:
+        def match_key(key: bytes) -> bool | Match[bytes] | None:
             if isinstance(key, str):
                 key = key.encode("utf-8")
             return regex.match(key) if regex is not None else True
@@ -580,7 +585,7 @@ class BaseFakeSocket:
         elif key.expireat is None:
             return -1
         else:
-            return int(round((key.expireat - self._db.time) * scale))
+            return int(round((key.expireat - self._db.time) * scale))  # noqa: RUF046  # int() satisfies mypy no-any-return
 
     def _encodefloat(self, value: float, humanfriendly: bool) -> bytes:
         if self.version >= (7,):

--- a/fakeredis/_client_setup.py
+++ b/fakeredis/_client_setup.py
@@ -5,13 +5,15 @@ arguments accepted by ``FakeRedis(...)`` (and friends) into the kwargs the
 real client class expects, wiring in a fakeredis connection pool.
 """
 
+from __future__ import annotations
+
 import inspect
 import uuid
 import warnings
-from typing import Any, Callable, Dict, Optional, Set, Type
+from typing import Any, Callable
 
 
-def _get_args_to_warn(method: Callable[..., Any]) -> Set[str]:
+def _get_args_to_warn(method: Callable[..., Any]) -> set[str]:
     """Collect argument names that ``method`` would emit deprecation warnings for.
 
     redis-py marks deprecated ``__init__`` arguments by wrapping the method in
@@ -34,7 +36,7 @@ def _get_args_to_warn(method: Callable[..., Any]) -> Set[str]:
     return res
 
 
-def convert_args_kwargs(klass: Type[object], *args: Any, **kwargs: Any) -> Dict[str, Any]:
+def convert_args_kwargs(klass: type[object], *args: Any, **kwargs: Any) -> dict[str, Any]:
     """Interpret the positional and keyword arguments according to the version of redis in use"""
     parameters = list(inspect.signature(klass.__init__).parameters.values())[1:]
     args_to_warn = _get_args_to_warn(klass.__init__)
@@ -75,16 +77,16 @@ _CONNECTION_POOL_KWARGS = frozenset(
 
 def build_client_kwds(
     *args: Any,
-    client_class: Type[Any],
-    connection_class: Type[Any],
-    connection_pool_class: Type[Any],
+    client_class: type[Any],
+    connection_class: type[Any],
+    connection_pool_class: type[Any],
     version: Any,
     server_type: Any,
     lua_modules: Any,
     server: Any,
-    connected: Optional[bool] = None,
+    connected: bool | None = None,
     **kwargs: Any,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build the kwargs passed to the underlying redis/valkey client ``__init__``.
 
     Creates a fakeredis connection pool when one isn't supplied. Shared by the sync
@@ -105,7 +107,7 @@ def build_client_kwds(
         if errors is not None:
             warnings.warn(DeprecationWarning('"errors" is deprecated. Use "encoding_errors" instead'))
             kwds["encoding_errors"] = errors
-        connection_kwargs: Dict[str, Any] = {
+        connection_kwargs: dict[str, Any] = {
             "connection_class": connection_class,
             "version": version,
             "server_type": server_type,

--- a/fakeredis/_command_args_parsing.py
+++ b/fakeredis/_command_args_parsing.py
@@ -1,7 +1,10 @@
-from typing import Tuple, List, Dict, Any, Sequence, Optional
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
 
 from . import _msgs as msgs
-from ._commands import Int, Float
+from ._commands import Float, Int
 from ._helpers import SimpleError, null_terminate
 
 
@@ -29,12 +32,12 @@ def _default_value(s: str) -> Any:
 
 
 def extract_args(
-    actual_args: Tuple[bytes, ...],
-    expected: Tuple[str, ...],
+    actual_args: tuple[bytes, ...],
+    expected: tuple[str, ...],
     error_on_unexpected: bool = True,
     left_from_first_unexpected: bool = True,
-    exception: Optional[str] = None,
-) -> Tuple[List[Any], Sequence[Any]]:
+    exception: str | None = None,
+) -> tuple[list[Any], Sequence[Any]]:
     """Parse argument values.
 
     Extract from actual arguments which arguments exist and their value if relevant.
@@ -65,9 +68,9 @@ def extract_args(
         ('~+maxlen', 'nx', 'xx', '+ex', 'keepttl'))
     10, [True, True, 324, False], None
     """
-    args_info: Dict[bytes, Tuple[int, int]] = {_encode_arg(k): (i, _count_params(k)) for (i, k) in enumerate(expected)}
+    args_info: dict[bytes, tuple[int, int]] = {_encode_arg(k): (i, _count_params(k)) for (i, k) in enumerate(expected)}
 
-    def _parse_params(key: bytes, ind: int, _actual_args: Tuple[bytes, ...]) -> Tuple[Any, int]:
+    def _parse_params(key: bytes, ind: int, _actual_args: tuple[bytes, ...]) -> tuple[Any, int]:
         """Parse an argument from actual args.
         :param key: Argument name to parse
         :param ind: index of argument in actual_args
@@ -110,14 +113,14 @@ def extract_args(
         else:
             return temp_res, expected_following
 
-    results: List[Any] = [_default_value(key) for key in expected]
+    results: list[Any] = [_default_value(key) for key in expected]
     left_args = []
     i = 0
     while i < len(actual_args):
         found = False
-        for key in args_info:
+        for key, arg_info in args_info.items():
             if null_terminate(actual_args[i]) == key:
-                arg_position, _ = args_info[key]
+                arg_position, _ = arg_info
                 results[arg_position], parsed = _parse_params(key, i, actual_args)
                 i += parsed
                 found = True
@@ -138,8 +141,8 @@ def extract_args(
 
 
 def parse_mpop_args(
-    command: str, numkeys: int, args: Tuple[bytes, ...], directions: Tuple[str, str]
-) -> Tuple[Sequence[bytes], int, bool]:
+    command: str, numkeys: int, args: tuple[bytes, ...], directions: tuple[str, str]
+) -> tuple[Sequence[bytes], int, bool]:
     """Validate the LMPOP/BLMPOP/ZMPOP/BZMPOP tail: keys, a direction token, optional COUNT.
 
     `args` is ``key [key ...] <directions[0] | directions[1]> [COUNT count]``.

--- a/fakeredis/_commands.py
+++ b/fakeredis/_commands.py
@@ -3,18 +3,21 @@ Helper classes and methods used in mixins implementing various commands.
 Unlike _helpers.py, here the methods should be used only in mixins.
 """
 
+from __future__ import annotations
+
 import functools
 import math
 import re
-from typing import Tuple, Union, Optional, Any, Type, List, Callable, Sequence, Dict, Set, Collection
+from collections.abc import Collection, Sequence
+from typing import Any, Callable
 
 from . import _msgs as msgs
-from ._helpers import null_terminate, SimpleError, Database
-from ._typing import VersionType, ServerType
+from ._helpers import Database, SimpleError, null_terminate
+from ._typing import ServerType, VersionType
 
 MAX_STRING_SIZE = 512 * 1024 * 1024
-SUPPORTED_COMMANDS: Dict[str, "Signature"] = {}  # Dictionary of supported commands name => Signature
-COMMANDS_WITH_SUB: Set[str] = set()  # Commands with sub-commands
+SUPPORTED_COMMANDS: dict[str, Signature] = {}  # Dictionary of supported commands name => Signature
+COMMANDS_WITH_SUB: set[str] = set()  # Commands with sub-commands
 
 
 class Key:
@@ -22,7 +25,7 @@ class Key:
 
     UNSPECIFIED = object()
 
-    def __init__(self, type_: Optional[Type[Any]] = None, missing_return: Any = UNSPECIFIED) -> None:
+    def __init__(self, type_: type[Any] | None = None, missing_return: Any = UNSPECIFIED) -> None:
         self.type_ = type_
         self.missing_return = missing_return
 
@@ -30,7 +33,7 @@ class Key:
 class Item:
     """An item stored in the database"""
 
-    __slots__ = ["value", "expireat"]
+    __slots__ = ["expireat", "value"]
 
     def __init__(self, value: Any) -> None:
         self.value = value
@@ -43,8 +46,8 @@ class CommandItem:
     It wraps an Item but has extra fields to manage updates and notifications.
     """
 
-    def __init__(self, key: bytes, db: Database, item: Optional["CommandItem"] = None, default: Any = None) -> None:
-        self._expireat: Optional[float]
+    def __init__(self, key: bytes, db: Database, item: CommandItem | None = None, default: Any = None) -> None:
+        self._expireat: float | None
         if item is None:
             self._value = default
             self._expireat = None
@@ -67,11 +70,11 @@ class CommandItem:
         self.expireat = None
 
     @property
-    def expireat(self) -> Optional[float]:
+    def expireat(self) -> float | None:
         return self._expireat
 
     @expireat.setter
-    def expireat(self, value: Optional[float]) -> None:
+    def expireat(self, value: float | None) -> None:
         self._expireat = value
         self._expireat_modified = True
         self._modified = True  # Since redis 6.0.7
@@ -129,7 +132,7 @@ class Int(RedisType):
         return cls.MIN_VALUE <= value <= cls.MAX_VALUE
 
     @classmethod
-    def decode(cls, value: bytes, decode_error: Optional[str] = None) -> int:
+    def decode(cls, value: bytes, decode_error: str | None = None) -> int:
         try:
             out = int(value)
             if not cls.valid(out) or str(out).encode() != value:
@@ -172,7 +175,7 @@ class Float(RedisType):
         allow_erange: bool = False,
         allow_empty: bool = False,
         crop_null: bool = False,
-        decode_error: Optional[str] = None,
+        decode_error: str | None = None,
     ) -> float:
         # Redis has some quirks in float parsing, with several variants.
         # See https://github.com/antirez/redis/issues/5706
@@ -188,12 +191,11 @@ class Float(RedisType):
             out = float(value)
             if math.isnan(out):
                 raise ValueError
-            if not allow_erange:
-                # Values that over- or under-flow are explicitly rejected by
-                # redis. This is a crude hack to determine whether the input
-                # may have been such a value.
-                if out in (math.inf, -math.inf, 0.0) and re.match(b"^[^a-zA-Z]*[1-9]", value):
-                    raise ValueError
+            # Values that over- or under-flow are explicitly rejected by
+            # redis. This is a crude hack to determine whether the input
+            # may have been such a value.
+            if not allow_erange and out in (math.inf, -math.inf, 0.0) and re.match(b"^[^a-zA-Z]*[1-9]", value):
+                raise ValueError
             return out
         except ValueError:
             raise SimpleError(decode_error or cls.DECODE_ERROR)
@@ -204,11 +206,11 @@ class Float(RedisType):
             return str(value).encode()
         elif humanfriendly:
             # Algorithm from `ld2string` in redis
-            out = "{:.17f}".format(value)
+            out = f"{value:.17f}"
             out = re.sub(r"\.?0+$", "", out)
             return out.encode()
         else:
-            return "{:.17g}".format(value).encode()
+            return f"{value:.17g}".encode()
 
 
 class Timeout(Float):
@@ -230,7 +232,7 @@ class BeforeAny:
     def __gt__(self, other: Any) -> bool:
         return False
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, BeforeAny)
 
     def __hash__(self) -> int:
@@ -242,7 +244,7 @@ class AfterAny:
     def __lt__(self, other: Any) -> bool:
         return False
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, AfterAny)
 
     def __hash__(self) -> int:
@@ -252,7 +254,7 @@ class AfterAny:
 class StringTest(RedisType):
     """Argument converter for sorted set LEX endpoints."""
 
-    def __init__(self, value: Union[bytes, BeforeAny, AfterAny], exclusive: bool):
+    def __init__(self, value: bytes | BeforeAny | AfterAny, exclusive: bool):
         self.value = value
         self.exclusive = exclusive
 
@@ -261,7 +263,7 @@ class StringTest(RedisType):
         return not self.exclusive
 
     @classmethod
-    def decode(cls, value: bytes) -> "StringTest":
+    def decode(cls, value: bytes) -> StringTest:
         if value == b"-":
             return cls(BeforeAny(), True)
         elif value == b"+":
@@ -279,9 +281,9 @@ class Signature:
         self,
         name: str,
         func_name: str,
-        fixed: Tuple[Type[Union[RedisType, bytes]]],
-        repeat: Tuple[Type[Union[RedisType, bytes]]] = (),  # type:ignore
-        args: Tuple[str] = (),  # type:ignore
+        fixed: tuple[type[RedisType | bytes]],
+        repeat: tuple[type[RedisType | bytes]] = (),  # type:ignore
+        args: tuple[str] = (),  # type:ignore
         flags: str = "",
         server_types: Collection[ServerType] = ("redis", "valkey", "dragonfly"),
     ):
@@ -291,7 +293,7 @@ class Signature:
         self.repeat = repeat
         self.flags = set(flags)
         self.command_args = args
-        self.server_types: Set[ServerType] = set(server_types)
+        self.server_types: set[ServerType] = set(server_types)
 
     def check_arity(self, args: Sequence[Any], version: VersionType) -> None:
         if len(args) == len(self.fixed):
@@ -306,7 +308,7 @@ class Signature:
 
     def apply(
         self, args: Sequence[Any], db: Database, version: VersionType
-    ) -> Union[Tuple[Any], Tuple[List[Any], List[CommandItem]]]:
+    ) -> tuple[Any] | tuple[list[Any], list[CommandItem]]:
         """Returns a tuple, which is either:
         - transformed args and a dict of CommandItems; or
         - a single containing a short-circuit return value
@@ -328,7 +330,7 @@ class Signature:
                 )
 
         # Second pass: read keys and check their types
-        command_items: List[CommandItem] = []
+        command_items: list[CommandItem] = []
         for i, (arg, type_) in enumerate(zip(args_list, types)):
             if isinstance(type_, Key):
                 item = db.get(arg)
@@ -362,7 +364,7 @@ def command(*args, **kwargs) -> Callable:  # type:ignore
         elif isinstance(cmd_names, str):
             create_signature(func, cmd_names.lower())
         else:
-            raise ValueError("command name should be a string or list of strings")
+            raise TypeError("command name should be a string or list of strings")
         return func
 
     return decorator
@@ -379,7 +381,7 @@ def delete_keys(*keys: CommandItem) -> int:
     return ans
 
 
-def fix_range(start: int, end: int, length: int) -> Tuple[int, int]:
+def fix_range(start: int, end: int, length: int) -> tuple[int, int]:
     # Redis handles negative slightly differently for zrange
     if start < 0:
         start = max(0, start + length)
@@ -391,7 +393,7 @@ def fix_range(start: int, end: int, length: int) -> Tuple[int, int]:
     return start, end + 1
 
 
-def fix_range_string(start: int, end: int, length: int) -> Tuple[int, int]:
+def fix_range_string(start: int, end: int, length: int) -> tuple[int, int]:
     # Negative number handling is based on the redis source code
     if 0 > start > end and end < 0:
         return -1, -1

--- a/fakeredis/_connection.py
+++ b/fakeredis/_connection.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import queue
 import warnings
-from typing import Any, Optional, Set, Sequence, Union, Type
+from collections.abc import Sequence
+from typing import Any
 
 import redis
 
-from fakeredis._fakesocket import FakeSocket
 from fakeredis._client_setup import build_client_kwds
+from fakeredis._fakesocket import FakeSocket
 from fakeredis._helpers import FakeSelector
+
 from . import _msgs as msgs
 from ._server import FakeBaseConnectionMixin, FakeServer
-from ._typing import Self, lib_version, RaiseErrorTypes, VersionType, ServerType
+from ._typing import RaiseErrorTypes, Self, ServerType, VersionType, lib_version
 
 
 class FakeBaseConnection(FakeBaseConnectionMixin):
@@ -18,7 +22,7 @@ class FakeBaseConnection(FakeBaseConnectionMixin):
     def connect(self) -> None:
         super().connect()  # type: ignore
         # The selector is set in redis.Connection.connect() after _connect() is called
-        self._selector: Optional[FakeSelector] = FakeSelector(self._sock)
+        self._selector: FakeSelector | None = FakeSelector(self._sock)
 
     def activate_maint_notifications_handling_if_enabled(self, *args: Any, **kwargs: Any) -> None:
         # redis-py>=8.0 performs a real socket.getaddrinfo() DNS lookup here to determine the
@@ -38,7 +42,7 @@ class FakeBaseConnection(FakeBaseConnectionMixin):
             client_info=self._client_info,
         )
 
-    def can_read(self, timeout: Optional[float] = 0) -> bool:
+    def can_read(self, timeout: float | None = 0) -> bool:
         if not self._server.connected:
             return True
         if not self._sock:
@@ -90,13 +94,13 @@ class FakeRedisMixin:
     def __init__(
         self,
         *args: Any,
-        server: Optional[FakeServer] = None,
-        version: Union[VersionType, str, int] = (7,),  # https://github.com/cunla/fakeredis-py/issues/401
+        server: FakeServer | None = None,
+        version: VersionType | str | int = (7,),  # https://github.com/cunla/fakeredis-py/issues/401
         server_type: ServerType = "redis",
-        lua_modules: Optional[Set[str]] = None,
-        client_class: Type[redis.Redis] = redis.Redis,
-        connection_class: Type[FakeBaseConnection] = FakeRedisConnection,
-        connection_pool_class: Type[redis.ConnectionPool] = redis.ConnectionPool,
+        lua_modules: set[str] | None = None,
+        client_class: type[redis.Redis] = redis.Redis,
+        connection_class: type[FakeBaseConnection] = FakeRedisConnection,
+        connection_pool_class: type[redis.ConnectionPool] = redis.ConnectionPool,
         **kwargs: Any,
     ) -> None:
         """
@@ -136,7 +140,7 @@ class FakeRedisMixin:
         pool = connection_pool_class.from_url(*args, **kwargs)
         # Now override how it creates connections
         pool.connection_class = kwargs.get("connection_class", FakeRedisConnection)
-        return cls(connection_pool=pool, *args, **kwargs)
+        return cls(*args, connection_pool=pool, **kwargs)
 
 
 class FakeStrictRedis(FakeRedisMixin, redis.StrictRedis):

--- a/fakeredis/_fakesocket.py
+++ b/fakeredis/_fakesocket.py
@@ -1,6 +1,9 @@
-from typing import Optional, Set, Any
+from __future__ import annotations
+
+from typing import Any
 
 from fakeredis.commands_mixins import (
+    AclCommandsMixin,
     ArrayCommandsMixin,
     BitmapCommandsMixin,
     ConnectionCommandsMixin,
@@ -11,22 +14,22 @@ from fakeredis.commands_mixins import (
     PubSubCommandsMixin,
     ScriptingCommandsMixin,
     ServerCommandsMixin,
-    StringCommandsMixin,
-    TransactionsCommandsMixin,
     SetCommandsMixin,
     StreamsCommandsMixin,
-    AclCommandsMixin,
+    StringCommandsMixin,
+    TransactionsCommandsMixin,
 )
 from fakeredis.stack import (
-    JSONCommandsMixin,
     BFCommandsMixin,
     CFCommandsMixin,
     CMSCommandsMixin,
-    TopkCommandsMixin,
+    JSONCommandsMixin,
     TDigestCommandsMixin,
     TimeSeriesCommandsMixin,
+    TopkCommandsMixin,
     VectorSetCommandsMixin,
 )
+
 from ._basefakesocket import BaseFakeSocket
 from ._server import FakeServer
 from .commands_mixins.sortedset_mixin import SortedSetCommandsMixin
@@ -65,8 +68,8 @@ class FakeSocket(
         self,
         server: FakeServer,
         db: int,
-        lua_modules: Optional[Set[str]] = None,  # noqa: F821
+        lua_modules: set[str] | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        super(FakeSocket, self).__init__(server, db, *args, lua_modules=lua_modules, **kwargs)
+        super().__init__(server, db, *args, lua_modules=lua_modules, **kwargs)

--- a/fakeredis/_helpers.py
+++ b/fakeredis/_helpers.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import re
 import threading
 import time
 import weakref
 from collections import defaultdict
-from typing import Any, AnyStr, Callable, Dict, Iterator, MutableMapping, Optional, Set
+from collections.abc import Iterator, MutableMapping
+from typing import Any, AnyStr, Callable
 
 
 class SimpleString:
@@ -31,8 +34,6 @@ class SimpleError(Exception):
 
 class NoResponse:
     """Returned by pub/sub commands to indicate that no response should be returned"""
-
-    pass
 
 
 OK = SimpleString(b"OK")
@@ -139,19 +140,19 @@ def compile_pattern(pattern_bytes: bytes) -> re.Pattern:  # type: ignore
             parts.append(re.escape(c))
     parts.append("\\Z")
     regex: bytes = "".join(parts).encode("latin-1")
-    return re.compile(regex, flags=re.S)
+    return re.compile(regex, flags=re.DOTALL)
 
 
 class Database(MutableMapping):  # type: ignore
-    def __init__(self, lock: Optional[threading.Lock], *args: Any, **kwargs: Any) -> None:
-        self._dict: Dict[bytes, Any] = dict(*args, **kwargs)
+    def __init__(self, lock: threading.Lock | None, *args: Any, **kwargs: Any) -> None:
+        self._dict: dict[bytes, Any] = dict(*args, **kwargs)
         self.time = 0.0
         # key to the set of connections
-        self._watches: Dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
+        self._watches: dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
         self.condition = threading.Condition(lock)
-        self._change_callbacks: Set[Callable[[], None]] = set()
+        self._change_callbacks: set[Callable[[], None]] = set()
 
-    def swap(self, other: "Database") -> None:
+    def swap(self, other: Database) -> None:
         self._dict, other._dict = other._dict, self._dict
         self.time, other.time = other.time, self.time
 
@@ -239,17 +240,16 @@ def valid_response_type(value: Any, protocol_version: int, nested: bool = False)
     allowed_types = _VALID_RESPONSE_TYPES_RESP2 if protocol_version == 2 else _VALID_RESPONSE_TYPES_RESP3
     if value is not None and not isinstance(value, allowed_types):
         return False
-    if isinstance(value, list):
-        if any(not valid_response_type(item, protocol_version, True) for item in value):
-            return False
-    return True
+    return not (
+        isinstance(value, list) and any(not valid_response_type(item, protocol_version, True) for item in value)
+    )
 
 
-class FakeSelector(object):
+class FakeSelector:
     def __init__(self, sock: Any):
         self.sock = sock
 
-    def check_can_read(self, timeout: Optional[float]) -> bool:
+    def check_can_read(self, timeout: float | None) -> bool:
         if self.sock.responses.qsize():
             return True
         if timeout is not None and timeout <= 0:

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import logging
 import threading
 import time
 import weakref
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
+from collections.abc import Sequence
+from typing import Any, ClassVar
 
 import redis
 
@@ -14,7 +17,7 @@ from fakeredis.model import AccessControlList, ClientInfo
 LOGGER = logging.getLogger("fakeredis")
 
 
-def _create_version(v: Union[Tuple[int, ...], int, str]) -> VersionType:
+def _create_version(v: tuple[int, ...] | int | str) -> VersionType:
     if isinstance(v, tuple):
         return v
     if isinstance(v, int):
@@ -32,13 +35,13 @@ def _version_to_str(v: VersionType) -> str:
 
 
 class FakeServer:
-    _servers_map: Dict[str, "FakeServer"] = {}
+    _servers_map: ClassVar[dict[str, FakeServer]] = {}
 
     def __init__(
         self,
         version: VersionType = (8,),
         server_type: ServerType = "redis",
-        config: Optional[Dict[bytes, bytes]] = None,
+        config: dict[bytes, bytes] | None = None,
     ) -> None:
         """Initialize a new FakeServer instance.
         :param version: The version of the server (e.g. 6, 7.4, "7.4.1", can also be a tuple)
@@ -50,24 +53,24 @@ class FakeServer:
         - `aclfile`: The path to the ACL file.
         """
         self.lock = threading.Lock()
-        self.dbs: Dict[int, Database] = defaultdict(lambda: Database(self.lock))
+        self.dbs: dict[int, Database] = defaultdict(lambda: Database(self.lock))
         # Maps channel/pattern to a weak set of sockets
-        self.script_cache: Dict[bytes, bytes] = {}  # Maps SHA1 to the script source
-        self.subscribers: Dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
-        self.psubscribers: Dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
-        self.ssubscribers: Dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
+        self.script_cache: dict[bytes, bytes] = {}  # Maps SHA1 to the script source
+        self.subscribers: dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
+        self.psubscribers: dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
+        self.ssubscribers: dict[bytes, weakref.WeakSet[Any]] = defaultdict(weakref.WeakSet)
         self.lastsave: int = int(time.time())
         self.connected = True
         # List of weakrefs to sockets that are being closed lazily
-        self.sockets: List[Any] = []
-        self.closed_sockets: List[Any] = []
+        self.sockets: list[Any] = []
+        self.closed_sockets: list[Any] = []
         self.version: VersionType = _create_version(version)
         if server_type not in ("redis", "dragonfly", "valkey"):
             raise ValueError(f"Unsupported server type: {server_type}")
         self.server_type: ServerType = server_type
-        self.config: Dict[bytes, bytes] = config or {}
+        self.config: dict[bytes, bytes] = config or {}
         self.acl: AccessControlList = AccessControlList()
-        self.clients: Dict[str, Dict[str, Any]] = {}
+        self.clients: dict[str, dict[str, Any]] = {}
         self._next_client_id = 1
         # CLIENT PAUSE state. Recorded so CLIENT PAUSE/UNPAUSE validate and round-trip,
         # but command processing is never actually suspended (see CLIENT PAUSE docs).
@@ -81,21 +84,21 @@ class FakeServer:
         return client_id
 
     @staticmethod
-    def get_server(key: str, version: VersionType, server_type: ServerType) -> "FakeServer":
+    def get_server(key: str, version: VersionType, server_type: ServerType) -> FakeServer:
         if key not in FakeServer._servers_map:
             FakeServer._servers_map[key] = FakeServer(version=version, server_type=server_type)
         return FakeServer._servers_map[key]
 
 
-class FakeBaseConnectionMixin(object):
+class FakeBaseConnectionMixin:
     def __init__(
         self,
         *args: Any,
         version: VersionType = (7, 0),
         server_type: ServerType = "redis",
-        server: Optional[FakeServer] = None,
-        client_class: Type[redis.Redis] = redis.Redis,
-        lua_modules: Optional[Set[str]] = None,
+        server: FakeServer | None = None,
+        client_class: type[redis.Redis] = redis.Redis,
+        lua_modules: set[str] | None = None,
         writer: Any = None,
         connected: bool = True,
         **kwargs: Any,
@@ -104,10 +107,10 @@ class FakeBaseConnectionMixin(object):
         Initializes the class and sets up the required attributes and configurations for the server and client interaction.
 
         """
-        self.client_name: Optional[str] = None
+        self.client_name: str | None = None
         self.server_key: str
         self._sock = None
-        self._selector: Optional[FakeSelector] = None
+        self._selector: FakeSelector | None = None
         self._server = server
         self._client_class = client_class
         self._lua_modules = lua_modules
@@ -125,34 +128,34 @@ class FakeBaseConnectionMixin(object):
         super().__init__(*args, **kwargs)
         protocol = getattr(self, "protocol", 2)
 
-        client_info = dict(
-            id=self._server.get_next_client_id(),
-            addr="127.0.0.1:0",
-            laddr="127.0.0.1:6379",
-            fd=8,
-            name="",
-            idle=0,
-            flags="N",
-            db=0,
-            sub=0,
-            psub=0,
-            ssub=0,
-            multi=-1,
-            qbuf=48,
-            qbuf_free=16842,
-            argv_mem=25,
-            multi_mem=0,
-            rbs=1024,
-            rbp=0,
-            obl=0,
-            oll=0,
-            omem=0,
-            tot_mem=18737,
-            events="r",
-            cmd="auth",
-            redir=-1,
-            resp=protocol,
-        )
+        client_info = {
+            "id": self._server.get_next_client_id(),
+            "addr": "127.0.0.1:0",
+            "laddr": "127.0.0.1:6379",
+            "fd": 8,
+            "name": "",
+            "idle": 0,
+            "flags": "N",
+            "db": 0,
+            "sub": 0,
+            "psub": 0,
+            "ssub": 0,
+            "multi": -1,
+            "qbuf": 48,
+            "qbuf_free": 16842,
+            "argv_mem": 25,
+            "multi_mem": 0,
+            "rbs": 1024,
+            "rbp": 0,
+            "obl": 0,
+            "oll": 0,
+            "omem": 0,
+            "tot_mem": 18737,
+            "events": "r",
+            "cmd": "auth",
+            "redir": -1,
+            "resp": protocol,
+        }
         client_info.update(client_info_arg)
         self._client_info = ClientInfo(**client_info)
 
@@ -166,10 +169,10 @@ class FakeBaseConnectionMixin(object):
         else:
             return response
 
-    def _add_to_local_cache(self, command: Sequence[str], response: Any, keys: List[Any]) -> None:
+    def _add_to_local_cache(self, command: Sequence[str], response: Any, keys: list[Any]) -> None:
         return None
 
-    def repr_pieces(self) -> List[Tuple[str, Any]]:
+    def repr_pieces(self) -> list[tuple[str, Any]]:
         pieces = [("server", self._server), ("db", self.db)]  # type: ignore[attr-defined]
         if self.client_name:
             pieces.append(("client_name", self.client_name))

--- a/fakeredis/_tcp_server.py
+++ b/fakeredis/_tcp_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fakeredis._helpers import SimpleError
 
 try:
@@ -13,13 +15,13 @@ import time
 from dataclasses import dataclass
 from io import BufferedIOBase
 from itertools import count
-from socketserver import ThreadingTCPServer, StreamRequestHandler
-from typing import Dict, Tuple, Any, Type, Union
+from socketserver import StreamRequestHandler, ThreadingTCPServer
+from typing import Any
 
 from redis.connection import DefaultParser
 
-from fakeredis import FakeServer, FakeRedisConnection
-from fakeredis._typing import VersionType, ServerType
+from fakeredis import FakeRedisConnection, FakeServer
+from fakeredis._typing import ServerType, VersionType
 
 LOGGER = logging.getLogger("fakeredis")
 # LOGGER.setLevel(logging.DEBUG)
@@ -40,7 +42,7 @@ def to_bytes(value: Any) -> bytes:
     return str(value).encode()
 
 
-_EXCEPTION_PREFIX_MAP: Dict[Type[Exception], str] = {
+_EXCEPTION_PREFIX_MAP: dict[type[Exception], str] = {
     v: k for k, v in DefaultParser.EXCEPTION_CLASSES.items() if isinstance(v, type) and issubclass(v, Exception)
 }
 
@@ -54,9 +56,9 @@ def _get_exception_prefix(e: Exception) -> str:
 
 @dataclass
 class Writer:
-    client_address: Tuple[str, int]
+    client_address: tuple[str, int]
     writer: BufferedIOBase
-    request_handler: "TCPFakeRequestHandler"
+    request_handler: TCPFakeRequestHandler
 
     def write(self, value: bytes) -> None:
         LOGGER.debug(f"<<< {self.client_address}: {value!r}")
@@ -83,7 +85,7 @@ class Resp2Writer(Writer):
             for item in value:
                 self.dump(item, dump_bulk=True)
         elif value is None:
-            self.write("$-1\r\n".encode())
+            self.write(b"$-1\r\n")
         elif isinstance(value, Exception):
             if isinstance(value, SimpleError):
                 self.write(f"-{value.args[0]}\r\n".encode())
@@ -97,7 +99,7 @@ class Resp3Writer(Writer):
     def dump(self, value: Any, dump_bulk: bool = False) -> None:
         value_type = type(value)
         if value is None:
-            self.write("_\r\n".encode())
+            self.write(b"_\r\n")
         elif value_type is str or value_type is bytes:
             value = to_bytes(value)
             if value.upper() == b"SHUTDOWN":
@@ -138,7 +140,7 @@ class Resp3Writer(Writer):
 
 
 class TCPFakeRequestHandler(StreamRequestHandler):
-    server: "TcpFakeServer"
+    server: TcpFakeServer
     shutdown_request: bool = False
 
     def setup(self) -> None:
@@ -197,7 +199,7 @@ class TCPFakeRequestHandler(StreamRequestHandler):
 class TcpFakeServer(ThreadingTCPServer):
     def __init__(
         self,
-        server_address: Tuple[Union[str, bytes, bytearray], int],
+        server_address: tuple[str | bytes | bytearray, int],
         bind_and_activate: bool = True,
         server_type: ServerType = "redis",
         server_version: VersionType = (8, 0),
@@ -208,7 +210,7 @@ class TcpFakeServer(ThreadingTCPServer):
         super().__init__(server_address, TCPFakeRequestHandler, bind_and_activate)
         self.fake_server = FakeServer(server_type=server_type, version=server_version)
         self.client_ids = count(0)
-        self.clients: Dict[int, FakeRedisConnection] = {}
+        self.clients: dict[int, FakeRedisConnection] = {}
 
     def shutdown(self) -> None:
         self._shutdown_event.set()

--- a/fakeredis/_typing.py
+++ b/fakeredis/_typing.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import sys
-from typing import Any, Literal, Union
+from typing import Any, Dict, List, Literal, Tuple, Union
 
 import redis
 import redis.asyncio
@@ -17,9 +19,11 @@ except ImportError:  # for Python < 3.8
     import importlib_metadata as metadata  # type: ignore
 
 lib_version = metadata.version("fakeredis")
-VersionType = tuple[int, ...]
+# These are evaluated at runtime (not annotations), so they must use typing
+# aliases rather than PEP 585 builtins to remain importable on Python 3.8.
+VersionType = Tuple[int, ...]
 ServerType = Literal["redis", "dragonfly", "valkey"]
-JsonType = Union[str, int, float, bool, None, dict[str, Any], list[Any]]
+JsonType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 RaiseErrorTypes: tuple[type[Exception], ...] = (redis.ResponseError, redis.AuthenticationError)
 ResponseErrorType = redis.ResponseError
 ClientType = redis.Redis

--- a/fakeredis/_typing.py
+++ b/fakeredis/_typing.py
@@ -1,16 +1,12 @@
 import sys
-from typing import Tuple, Union, Dict, Any, List, Type
+from typing import Any, Literal, Union
 
 import redis
 import redis.asyncio
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal
 if sys.version_info >= (3, 11):
-    from typing import Self
     from asyncio import timeout as async_timeout
+    from typing import Self
 else:
     from async_timeout import timeout as async_timeout
     from typing_extensions import Self
@@ -21,10 +17,10 @@ except ImportError:  # for Python < 3.8
     import importlib_metadata as metadata  # type: ignore
 
 lib_version = metadata.version("fakeredis")
-VersionType = Tuple[int, ...]
+VersionType = tuple[int, ...]
 ServerType = Literal["redis", "dragonfly", "valkey"]
-JsonType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
-RaiseErrorTypes: Tuple[Type[Exception], ...] = (redis.ResponseError, redis.AuthenticationError)
+JsonType = Union[str, int, float, bool, None, dict[str, Any], list[Any]]
+RaiseErrorTypes: tuple[type[Exception], ...] = (redis.ResponseError, redis.AuthenticationError)
 ResponseErrorType = redis.ResponseError
 ClientType = redis.Redis
 AsyncClientType = redis.asyncio.Redis
@@ -39,12 +35,12 @@ except ImportError:
     pass
 
 __all__ = [
-    "Self",
-    "async_timeout",
-    "VersionType",
-    "ServerType",
     "ClientType",
-    "lib_version",
     "RaiseErrorTypes",
     "ResponseErrorType",
+    "Self",
+    "ServerType",
+    "VersionType",
+    "async_timeout",
+    "lib_version",
 ]

--- a/fakeredis/_valkey.py
+++ b/fakeredis/_valkey.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 import valkey

--- a/fakeredis/_valkey.py
+++ b/fakeredis/_valkey.py
@@ -1,13 +1,13 @@
-from typing import Any, Dict
+from typing import Any
 
 import valkey
 
-from ._connection import FakeRedisMixin, FakeBaseConnection
+from ._connection import FakeBaseConnection, FakeRedisMixin
 from ._typing import Self
 from .aioredis import FakeAsyncRedisMixin, FakeBaseAsyncConnection
 
 
-def _validate_server_type(args_dict: Dict[str, Any]) -> None:
+def _validate_server_type(args_dict: dict[str, Any]) -> None:
     if "server_type" in args_dict and args_dict["server_type"] != "valkey":
         raise ValueError("server_type must be valkey")
     args_dict.setdefault("server_type", "valkey")
@@ -18,12 +18,10 @@ def _validate_server_type(args_dict: Dict[str, Any]) -> None:
 
 class FakeValkeyConnection(FakeBaseConnection, valkey.Connection):
     _connection_error_class = valkey.ConnectionError
-    pass
 
 
 class FakeAysncValkeyConnection(FakeBaseAsyncConnection, valkey.asyncio.Connection):
     _connection_error_class = valkey.ConnectionError
-    pass
 
 
 class FakeValkey(FakeRedisMixin, valkey.Valkey):
@@ -39,7 +37,7 @@ class FakeValkey(FakeRedisMixin, valkey.Valkey):
 class FakeStrictValkey(FakeRedisMixin, valkey.StrictValkey):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         _validate_server_type(kwargs)
-        super(FakeStrictValkey, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def from_url(cls, *args: Any, **kwargs: Any) -> Self:
@@ -52,7 +50,7 @@ class FakeAsyncValkey(FakeAsyncRedisMixin, valkey.asyncio.Valkey):
         kwargs.setdefault("connection_class", FakeAysncValkeyConnection)
         kwargs.setdefault("connection_pool_class", valkey.asyncio.ConnectionPool)
         _validate_server_type(kwargs)
-        super(FakeAsyncValkey, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def from_url(cls, *args: Any, **kwargs: Any) -> Self:

--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import threading
 import warnings
-from typing import Any, Callable, Iterable, Optional, Sequence, Set, Type, Union
+from collections.abc import Iterable, Sequence
+from typing import Any, Callable
 
 import redis.asyncio as redis_async
 from redis import ResponseError
@@ -51,7 +52,7 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
 
     async def _async_blocking(
         self,
-        timeout: Optional[Union[float, int]],
+        timeout: float | None,
         func: Callable[[bool], Any],
         event: asyncio.Event,
         callback: Callable[[], None],
@@ -87,7 +88,7 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
 
     def _blocking(
         self,
-        timeout: Optional[Union[float, int]],
+        timeout: float | None,
         func: Callable[[bool], None],
     ) -> Any:
         loop = asyncio.get_event_loop()
@@ -119,7 +120,7 @@ class FakeReader:
 
 class FakeWriter:
     def __init__(self, socket: AsyncFakeSocket) -> None:
-        self._socket: Optional[AsyncFakeSocket] = socket
+        self._socket: AsyncFakeSocket | None = socket
 
     def close(self) -> None:
         self._socket = None
@@ -143,11 +144,11 @@ class FakeBaseAsyncConnection(FakeBaseConnectionMixin):
     async def _connect(self) -> None:
         if not self._server.connected:
             raise self._connection_error_class(msgs.CONNECTION_ERROR_MSG)
-        self._sock: Optional[AsyncFakeSocket] = AsyncFakeSocket(
+        self._sock: AsyncFakeSocket | None = AsyncFakeSocket(
             self._server, self.db, client_class=self._client_class, lua_modules=self._lua_modules
         )
-        self._reader: Optional[FakeReader] = FakeReader(self._sock)
-        self._writer: Optional[FakeWriter] = FakeWriter(self._sock)
+        self._reader: FakeReader | None = FakeReader(self._sock)
+        self._writer: FakeWriter | None = FakeWriter(self._sock)
 
     def __del__(self) -> None:
         # Ensure _writer is cleared even if disconnect() was never called
@@ -163,7 +164,7 @@ class FakeBaseAsyncConnection(FakeBaseConnectionMixin):
         self._writer = None
         await super().disconnect(**kwargs)
 
-    async def can_read(self, timeout: Optional[float] = 0) -> bool:
+    async def can_read(self, timeout: float | None = 0) -> bool:
         if not self.is_connected:
             await self.connect()
         if timeout == 0:
@@ -211,7 +212,7 @@ class FakeBaseAsyncConnection(FakeBaseConnectionMixin):
                     await self.disconnect()
                 raise self._connection_error_class(msgs.CONNECTION_ERROR_MSG)
         else:
-            timeout: Optional[float] = kwargs.pop("timeout", None)
+            timeout: float | None = kwargs.pop("timeout", None)
             can_read = await self.can_read(timeout)
             response = await self._reader.read(0) if can_read and self._reader else None
         if isinstance(response, RaiseErrorTypes):
@@ -229,13 +230,13 @@ class FakeAsyncRedisMixin:
     def __init__(
         self,
         *args: Any,
-        server: Optional[FakeServer] = None,
-        version: Union[VersionType, str, int] = (7,),  # https://github.com/cunla/fakeredis-py/issues/401
+        server: FakeServer | None = None,
+        version: VersionType | str | int = (7,),  # https://github.com/cunla/fakeredis-py/issues/401
         server_type: ServerType = "redis",
-        lua_modules: Optional[Set[str]] = None,
-        client_class: Type[redis_async.Redis] = redis_async.Redis,
-        connection_class: Type[FakeBaseAsyncConnection] = FakeAsyncRedisConnection,
-        connection_pool_class: Type[redis_async.connection.ConnectionPool] = redis_async.connection.ConnectionPool,
+        lua_modules: set[str] | None = None,
+        client_class: type[redis_async.Redis] = redis_async.Redis,
+        connection_class: type[FakeBaseAsyncConnection] = FakeAsyncRedisConnection,
+        connection_pool_class: type[redis_async.connection.ConnectionPool] = redis_async.connection.ConnectionPool,
         **kwargs: Any,
     ) -> None:
         connected = kwargs.pop("connected", True)
@@ -261,7 +262,7 @@ class FakeAsyncRedisMixin:
         super().__init__(**kwds)
 
     @classmethod
-    def from_url(cls, url: str, **kwargs: Any) -> "FakeAsyncRedisMixin":
+    def from_url(cls, url: str, **kwargs: Any) -> FakeAsyncRedisMixin:
         self: redis_async.Redis = super().from_url(url, **kwargs)
         pool = self.connection_pool  # Now override how it creates connections
         pool.connection_class = kwargs.pop("connection_class", FakeAsyncRedisConnection)

--- a/fakeredis/commands_mixins/__init__.py
+++ b/fakeredis/commands_mixins/__init__.py
@@ -19,14 +19,15 @@ try:
     from .scripting_mixin import ScriptingCommandsMixin
 except ImportError:
 
-    class ScriptingCommandsMixin:  # type: ignore  # noqa: E303
+    class ScriptingCommandsMixin:  # type: ignore
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             kwargs.pop("lua_modules", None)
             self.server_supports_lua_scripts = False
-            super(ScriptingCommandsMixin, self).__init__(*args, **kwargs)  # type: ignore
+            super().__init__(*args, **kwargs)
 
 
 __all__ = [
+    "AclCommandsMixin",
     "ArrayCommandsMixin",
     "BitmapCommandsMixin",
     "ConnectionCommandsMixin",
@@ -36,10 +37,9 @@ __all__ = [
     "ListCommandsMixin",
     "PubSubCommandsMixin",
     "ScriptingCommandsMixin",
-    "TransactionsCommandsMixin",
     "ServerCommandsMixin",
     "SetCommandsMixin",
     "StreamsCommandsMixin",
     "StringCommandsMixin",
-    "AclCommandsMixin",
+    "TransactionsCommandsMixin",
 ]

--- a/fakeredis/commands_mixins/acl_mixin.py
+++ b/fakeredis/commands_mixins/acl_mixin.py
@@ -1,23 +1,24 @@
+from __future__ import annotations
+
 import secrets
-from typing import List, Dict, Optional, Union
 
 from fakeredis import _msgs as msgs
-from fakeredis._commands import command, Int
-from fakeredis._helpers import SimpleError, OK, casematch, SimpleString
+from fakeredis._commands import Int, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import AccessControlList, get_categories, get_commands_by_category
 
 
 class AclCommandsMixin(CommandsMixinBase):
     @property
-    def _server_config(self) -> Dict[bytes, bytes]:
+    def _server_config(self) -> dict[bytes, bytes]:
         return self._server.config
 
     @property
     def _acl(self) -> AccessControlList:
         return self._server.acl
 
-    def _check_user_password(self, username: bytes, password: Optional[bytes]) -> bool:
+    def _check_user_password(self, username: bytes, password: bytes | None) -> bool:
         return self._acl.get_user_acl(username).check_password(password)
 
     def _set_user_acl(self, username: bytes, *args: bytes) -> None:
@@ -94,7 +95,7 @@ class AclCommandsMixin(CommandsMixinBase):
         raise SimpleError(msgs.AUTH_FAILURE)
 
     @command(name="ACL CAT", fixed=(), repeat=(bytes,))
-    def acl_cat(self, *category: bytes) -> List[bytes]:
+    def acl_cat(self, *category: bytes) -> list[bytes]:
         if len(category) == 0:
             res = get_categories()
         else:
@@ -115,7 +116,7 @@ class AclCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="ACL LIST", fixed=(), repeat=())
-    def acl_list(self) -> List[bytes]:
+    def acl_list(self) -> list[bytes]:
         return self._acl.as_rules()
 
     @command(name="ACL DELUSER", fixed=(bytes,), repeat=())
@@ -124,12 +125,12 @@ class AclCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="ACL GETUSER", fixed=(bytes,), repeat=())
-    def acl_getuser(self, username: bytes) -> List[Union[bytes, List[bytes], List[Dict[str, bytes]]]]:
+    def acl_getuser(self, username: bytes) -> list[bytes | list[bytes] | list[dict[str, bytes]]]:
         res = self._acl.get_user_acl(username).as_array()
         return res
 
     @command(name="ACL USERS", fixed=(), repeat=())
-    def acl_users(self) -> List[bytes]:
+    def acl_users(self) -> list[bytes]:
         res = self._acl.get_users()
         return res
 
@@ -172,7 +173,7 @@ class AclCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="ACL LOG", fixed=(), repeat=(bytes,))
-    def acl_log(self, *args: bytes) -> Union[SimpleString, List[Dict[str, bytes]]]:
+    def acl_log(self, *args: bytes) -> SimpleString | list[dict[str, bytes]]:
         if len(args) == 1 and casematch(args[0], b"RESET"):
             self._acl.reset_log()
             return OK

--- a/fakeredis/commands_mixins/array_mixin.py
+++ b/fakeredis/commands_mixins/array_mixin.py
@@ -1,7 +1,9 @@
-from typing import Any, List, Optional, Set, Tuple
+from __future__ import annotations
+
+from typing import Any
 
 from fakeredis import _msgs as msgs
-from fakeredis._commands import Key, Int, command, CommandItem
+from fakeredis._commands import CommandItem, Int, Key, command
 from fakeredis._helpers import SimpleError, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model._array import Array
@@ -101,7 +103,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
             return 0
         arr: Array = key.value
         # args: start1, end1, start2, end2, ...
-        to_delete: Set[int] = set()
+        to_delete: set[int] = set()
         for i in range(0, len(args), 2):
             start, end = args[i], args[i + 1]
             lo, hi = (start, end) if start <= end else (end, start)
@@ -124,14 +126,14 @@ class ArrayCommandsMixin(CommandsMixinBase):
     # ── read commands ────────────────────────────────────────────────────────
 
     @command((Key(Array, None), Int))
-    def arget(self, key: CommandItem, index: int) -> Optional[bytes]:
+    def arget(self, key: CommandItem, index: int) -> bytes | None:
         if not key:
             return None
         arr: Array = key.value
         return arr.get(index)
 
     @command((Key(Array), Int, Int))
-    def argetrange(self, key: CommandItem, start: int, end: int) -> List[Optional[bytes]]:
+    def argetrange(self, key: CommandItem, start: int, end: int) -> list[bytes | None]:
         if start <= end:
             indices = list(range(start, end + 1))
         else:
@@ -142,7 +144,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
         return [arr.get(i) for i in indices]
 
     @command((Key(Array), Int), (Int,))
-    def armget(self, key: CommandItem, first_idx: int, *more_idx: int) -> List[Optional[bytes]]:
+    def armget(self, key: CommandItem, first_idx: int, *more_idx: int) -> list[bytes | None]:
         arr: Array = key.value
         return [arr.get(idx) for idx in [first_idx] + list(more_idx)]
 
@@ -168,7 +170,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
         return arr._cursor
 
     @command((Key(Array, []), Int), (bytes,))
-    def arlastitems(self, key: CommandItem, count: int, *args: bytes) -> List[bytes]:
+    def arlastitems(self, key: CommandItem, count: int, *args: bytes) -> list[bytes]:
         if not key:
             return []
         rev = any(casematch(a, b"rev") for a in args)
@@ -179,7 +181,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
         return items
 
     @command((Key(Array, []), bytes, bytes), (bytes,))
-    def arscan(self, key: CommandItem, start_b: bytes, end_b: bytes, *args: bytes) -> List[Any]:
+    def arscan(self, key: CommandItem, start_b: bytes, end_b: bytes, *args: bytes) -> list[Any]:
         if not key:
             return []
         arr: Array = key.value
@@ -189,7 +191,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
         except ValueError:
             raise SimpleError(msgs.INVALID_INT_MSG)
 
-        limit: Optional[int] = None
+        limit: int | None = None
         i = 0
         while i < len(args):
             if casematch(args[i], b"limit"):
@@ -207,16 +209,16 @@ class ArrayCommandsMixin(CommandsMixinBase):
         return [[idx, val] for idx, val in pairs]
 
     @command((Key(Array, []), bytes, bytes), (bytes,))
-    def argrep(self, key: CommandItem, start_b: bytes, end_b: bytes, *args: bytes) -> List[Any]:
+    def argrep(self, key: CommandItem, start_b: bytes, end_b: bytes, *args: bytes) -> list[Any]:
         if not key:
             return []
         arr: Array = key.value
         start = _parse_range_end(start_b, arr, is_start=True)
         end = _parse_range_end(end_b, arr, is_start=False)
 
-        predicates: List[Tuple[str, str]] = []
+        predicates: list[tuple[str, str]] = []
         use_and = False
-        limit: Optional[int] = None
+        limit: int | None = None
         withvalues = False
         nocase = False
 
@@ -256,7 +258,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
 
         matches = arr.grep_range(start, end, predicates, use_and, limit, nocase)
-        result: List[Any] = []
+        result: list[Any] = []
         for idx, val in matches:
             if withvalues:
                 result.append([idx, val])
@@ -276,7 +278,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
             raise SimpleError(msgs.INVALID_INT_MSG)
 
         op = op_b.lower().decode()
-        operand: Optional[bytes] = None
+        operand: bytes | None = None
         if op == "match":
             if not args:
                 raise SimpleError(msgs.SYNTAX_ERROR_MSG)
@@ -292,7 +294,7 @@ class ArrayCommandsMixin(CommandsMixinBase):
             raise SimpleError("no such key")
         arr: Array = key.value
         full = any(casematch(a, b"full") for a in args)
-        info: List[Any] = [
+        info: list[Any] = [
             b"count",
             arr.count(),
             b"len",

--- a/fakeredis/commands_mixins/bitmap_mixin.py
+++ b/fakeredis/commands_mixins/bitmap_mixin.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import re
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable
 
 from fakeredis import _msgs as msgs
 from fakeredis._commands import MAX_STRING_SIZE, CommandItem, Int, Key, command, fix_range, fix_range_string
@@ -197,7 +199,7 @@ class BitmapCommandsMixin(CommandsMixinBase):
 
     def _bitfield_get(self, key: CommandItem, encoding: BitfieldEncoding, offset: int) -> int:
         ans = 0
-        for i in range(0, encoding.size):
+        for i in range(encoding.size):
             ans <<= 1
             if self.getbit(key, offset + i):
                 ans += -1 if encoding.signed and i == 0 else 1
@@ -209,9 +211,9 @@ class BitmapCommandsMixin(CommandsMixinBase):
         encoding: BitfieldEncoding,
         offset: int,
         overflow: bytes,
-        value: Optional[int] = None,
+        value: int | None = None,
         incr: int = 0,
-    ) -> Optional[int]:
+    ) -> int | None:
         if encoding.signed:
             min_value = -(1 << (encoding.size - 1))
             max_value = (1 << (encoding.size - 1)) - 1
@@ -239,15 +241,15 @@ class BitmapCommandsMixin(CommandsMixinBase):
         if encoding.signed and new_value > max_value:
             new_value -= 1 << encoding.size
 
-        for i in range(0, encoding.size):
+        for i in range(encoding.size):
             bit = (new_value >> (encoding.size - i - 1)) & 1
             self.setbit(key, offset + i, bit)
         return new_value if value is None else ans
 
     @command(name="bitfield", fixed=(Key(bytes),), repeat=(bytes,))
-    def bitfield(self, key: CommandItem, *args: bytes) -> List[Optional[int]]:
+    def bitfield(self, key: CommandItem, *args: bytes) -> list[int | None]:
         overflow = b"WRAP"
-        results: List[Optional[int]] = []
+        results: list[int | None] = []
         i = 0
         while i < len(args):
             if casematch(args[i], b"overflow") and i + 1 < len(args):

--- a/fakeredis/commands_mixins/connection_mixin.py
+++ b/fakeredis/commands_mixins/connection_mixin.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import time
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Union
+from collections.abc import Sequence
+from typing import Any, Callable
 
 import fakeredis
 from fakeredis import _msgs as msgs
-from fakeredis._commands import command, DbIndex, Int
-from fakeredis._helpers import SimpleError, OK, SimpleString, NoResponse, casematch
+from fakeredis._commands import DbIndex, Int, command
+from fakeredis._helpers import OK, NoResponse, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 
 PONG = SimpleString(b"PONG")
@@ -18,14 +21,14 @@ class ConnectionCommandsMixin(CommandsMixinBase):
     _clear_watches: Callable[[], None]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super(ConnectionCommandsMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._db_num: int
         self._pubsub: int
-        self._transaction: Optional[List[Any]]
+        self._transaction: list[Any] | None
         self._transaction_failed: bool
         self._killed: bool
         self._blocked: bool
-        self._unblock_reason: Optional[bytes]
+        self._unblock_reason: bytes | None
         self._reply_off: bool
         self._reply_skip: bool
         self._reply_skip_next: bool
@@ -37,7 +40,7 @@ class ConnectionCommandsMixin(CommandsMixinBase):
         return message
 
     @command((), (bytes,))
-    def ping(self, *args: bytes) -> Union[List[bytes], bytes, SimpleString]:
+    def ping(self, *args: bytes) -> list[bytes] | bytes | SimpleString:
         if len(args) > 1:
             msg = msgs.WRONG_ARGS_MSG6.format("ping")
             raise SimpleError(msg)
@@ -101,7 +104,7 @@ class ConnectionCommandsMixin(CommandsMixinBase):
         return b"\n".join(res)
 
     @command(name="HELLO", fixed=(), repeat=(bytes,))
-    def hello(self, *args: bytes) -> Dict[str, Any]:
+    def hello(self, *args: bytes) -> dict[str, Any]:
         self._client_info["resp"] = 2 if len(args) == 0 else Int.decode(args[0])
         i = 1
         while i < len(args):
@@ -155,7 +158,7 @@ class ConnectionCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="CLIENT REPLY", fixed=(bytes,), repeat=())
-    def client_reply(self, mode: bytes) -> Union[SimpleString, NoResponse]:
+    def client_reply(self, mode: bytes) -> SimpleString | NoResponse:
         if casematch(mode, b"on"):
             self._reply_off = self._reply_skip = self._reply_skip_next = False
             return OK
@@ -217,8 +220,8 @@ class ConnectionCommandsMixin(CommandsMixinBase):
     def _client_age(sock: Any) -> int:
         return int(time.time()) - int(sock._client_info.get("-created", 0))
 
-    def _parse_client_kill_filters(self, args: Sequence[bytes]) -> Dict[str, Any]:
-        filters: Dict[str, Any] = {}
+    def _parse_client_kill_filters(self, args: Sequence[bytes]) -> dict[str, Any]:
+        filters: dict[str, Any] = {}
         i = 0
         while i < len(args):
             if i + 1 >= len(args):
@@ -268,12 +271,12 @@ class ConnectionCommandsMixin(CommandsMixinBase):
 
     def _kill_clients(
         self,
-        addr: Optional[bytes] = None,
-        laddr: Optional[bytes] = None,
-        client_id: Optional[int] = None,
-        client_type: Optional[bytes] = None,
-        user: Optional[bytes] = None,
-        maxage: Optional[int] = None,
+        addr: bytes | None = None,
+        laddr: bytes | None = None,
+        client_id: int | None = None,
+        client_type: bytes | None = None,
+        user: bytes | None = None,
+        maxage: int | None = None,
         skipme: bool = True,
     ) -> int:
         killed = 0
@@ -298,7 +301,7 @@ class ConnectionCommandsMixin(CommandsMixinBase):
         return killed
 
     @command(name="CLIENT KILL", fixed=(bytes,), repeat=(bytes,))
-    def client_kill(self, *args: bytes) -> Union[SimpleString, int]:
+    def client_kill(self, *args: bytes) -> SimpleString | int:
         # The one-argument form is the old `CLIENT KILL addr:port` syntax, which reports
         # whether it killed anything rather than a count, and may kill the caller.
         if len(args) == 1:
@@ -309,14 +312,14 @@ class ConnectionCommandsMixin(CommandsMixinBase):
 
     def _discard_subscriptions(self) -> None:
         """Drop every subscription without sending the usual unsubscribe confirmations."""
-        subscriber_maps: List[Dict[bytes, Any]] = [
+        subscriber_maps: list[dict[bytes, Any]] = [
             self._server.subscribers,
             self._server.psubscribers,
             self._server.ssubscribers,
         ]
         for subscribers in subscriber_maps:
             for channel in list(subscribers.keys()):
-                subs: Set[Any] = subscribers[channel]
+                subs: set[Any] = subscribers[channel]
                 subs.discard(self)
                 if not subs:
                     del subscribers[channel]

--- a/fakeredis/commands_mixins/generic_mixin.py
+++ b/fakeredis/commands_mixins/generic_mixin.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
+
 import hashlib
 import pickle
 import random
-from typing import Tuple, Any, Callable, List, Optional, Union, Sequence
+from collections.abc import Sequence
+from typing import Any, Callable
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import command, Key, Int, DbIndex, BeforeAny, CommandItem, delete_keys, Float
-from fakeredis._helpers import compile_pattern, SimpleError, OK, casematch, SimpleString
+from fakeredis._commands import BeforeAny, CommandItem, DbIndex, Float, Int, Key, command, delete_keys
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch, compile_pattern
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
-from fakeredis.model import ZSet, Hash, ExpiringMembersSet
+from fakeredis.model import ExpiringMembersSet, Hash, ZSet
 
 
 class SortFloat(Float):
@@ -22,21 +25,21 @@ class SortFloat(Float):
         allow_erange: bool = False,
         allow_empty: bool = True,
         crop_null: bool = True,
-        decode_error: Optional[str] = None,
+        decode_error: str | None = None,
     ) -> float:
         return super().decode(value, allow_leading_whitespace=True, allow_empty=True, crop_null=True)
 
 
 class GenericCommandsMixin(CommandsMixinBase):
     _ttl: Callable[[CommandItem, float], int]
-    _scan: Callable[[Sequence[bytes], int, bytes], List[Union[bytes, List[bytes]]]]
+    _scan: Callable[[Sequence[bytes], int, bytes], list[bytes | list[bytes]]]
     _key_value_type: Callable[[CommandItem], SimpleString]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super(GenericCommandsMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._db_num: int
 
-    def _lookup_key(self, key: bytes, pattern: bytes) -> Optional[bytes]:
+    def _lookup_key(self, key: bytes, pattern: bytes) -> bytes | None:
         """Python implementation of lookupKeyByPattern from redis"""
         if pattern == b"#":
             return key
@@ -89,7 +92,7 @@ class GenericCommandsMixin(CommandsMixinBase):
         return delete_keys(*keys)
 
     @command(name="DUMP", fixed=(Key(missing_return=None),))
-    def dump(self, key: CommandItem) -> Optional[bytes]:
+    def dump(self, key: CommandItem) -> bytes | None:
         value = pickle.dumps(key.value)
         checksum = hashlib.sha1(value).digest()
         return checksum + value
@@ -112,7 +115,7 @@ class GenericCommandsMixin(CommandsMixinBase):
         return self._expireat(key, float(timestamp), *args)
 
     @command(name="KEYS", fixed=(bytes,))
-    def keys(self, pattern: bytes) -> List[bytes]:
+    def keys(self, pattern: bytes) -> list[bytes]:
         if pattern == b"*":
             return list(self._db)
         else:
@@ -166,8 +169,8 @@ class GenericCommandsMixin(CommandsMixinBase):
         return int(key.expireat * 1000)
 
     @command(name="RANDOMKEY", fixed=())
-    def randomkey(self) -> Optional[bytes]:
-        keys: List[bytes] = list(self._db.keys())
+    def randomkey(self) -> bytes | None:
+        keys: list[bytes] = list(self._db.keys())
         if not keys:
             return None
         return random.choice(keys)
@@ -211,14 +214,14 @@ class GenericCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="SCAN", fixed=(Int,), repeat=(bytes, bytes))
-    def scan(self, cursor: int, *args: bytes) -> List[Union[bytes, List[bytes]]]:
+    def scan(self, cursor: int, *args: bytes) -> list[bytes | list[bytes]]:
         return self._scan(list(self._db), cursor, *args)
 
     @command(name="SORT", fixed=(Key(),), repeat=(bytes,))
-    def sort(self, key: CommandItem, *args: bytes) -> Union[int, List[Any]]:
+    def sort(self, key: CommandItem, *args: bytes) -> int | list[Any]:
         if key.value is not None and not isinstance(key.value, (ExpiringMembersSet, list, ZSet)):
             raise SimpleError(msgs.WRONGTYPE_MSG)
-        ((asc, desc, alpha, store, sortby, (limit_start, limit_count)), left_args) = extract_args(
+        ((_asc, desc, alpha, store, sortby, (limit_start, limit_count)), left_args) = extract_args(
             args,
             ("asc", "desc", "alpha", "*store", "*by", "++limit"),
             error_on_unexpected=False,
@@ -254,14 +257,14 @@ class GenericCommandsMixin(CommandsMixinBase):
 
         if not dontsort:
 
-            def sort_key(val: bytes) -> Union[bytes, BeforeAny]:
+            def sort_key(val: bytes) -> bytes | BeforeAny:
                 byval = self._lookup_key(val, sortby)
                 # TODO: use locale.strxfrm when not storing? But then need to decode too.
                 if byval is None:
                     return BeforeAny()
                 return byval
 
-            def sort_key_score(val: bytes) -> Tuple[float, bytes]:
+            def sort_key_score(val: bytes) -> tuple[float, bytes]:
                 byval = self._lookup_key(val, sortby)
                 score = SortFloat.decode(byval) if byval is not None else 0.0
                 return score, val
@@ -289,10 +292,10 @@ class GenericCommandsMixin(CommandsMixinBase):
             return out
 
     @command(name="SORT_RO", fixed=(Key(),), repeat=(bytes,))
-    def sort_ro(self, key: CommandItem, *args: bytes) -> List[bytes]:
+    def sort_ro(self, key: CommandItem, *args: bytes) -> list[bytes]:
         if key.value is not None and not isinstance(key.value, (set, list, ZSet)):
             raise SimpleError(msgs.WRONGTYPE_MSG)
-        ((asc, desc, alpha, sortby, (limit_start, limit_count)), left_args) = extract_args(
+        ((_asc, desc, alpha, sortby, (limit_start, limit_count)), left_args) = extract_args(
             args,
             ("asc", "desc", "alpha", "*by", "++limit"),
             error_on_unexpected=False,
@@ -328,14 +331,14 @@ class GenericCommandsMixin(CommandsMixinBase):
 
         if not dontsort:
 
-            def sort_key(val: bytes) -> Union[bytes, BeforeAny]:
+            def sort_key(val: bytes) -> bytes | BeforeAny:
                 byval = self._lookup_key(val, sortby)
                 # TODO: use locale.strxfrm when not storing? But then need to decode too.
                 if byval is None:
                     return BeforeAny()
                 return byval
 
-            def sort_key_score(val: bytes) -> Tuple[float, bytes]:
+            def sort_key_score(val: bytes) -> tuple[float, bytes]:
                 byval = self._lookup_key(val, sortby)
                 score = SortFloat.decode(byval) if byval is not None else 0.0
                 return score, val
@@ -348,7 +351,7 @@ class GenericCommandsMixin(CommandsMixinBase):
         elif desc and isinstance(key.value, (list, ZSet)):
             items.reverse()
 
-        out: List[bytes] = []
+        out: list[bytes] = []
         for row in items[start:end]:
             for g in get:
                 v = self._lookup_key(row, g)

--- a/fakeredis/commands_mixins/geo_mixin.py
+++ b/fakeredis/commands_mixins/geo_mixin.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import sys
 from collections import namedtuple
-from typing import List, Any, Optional, Union
+from typing import Any
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import command, Key, Float, CommandItem
+from fakeredis._commands import CommandItem, Float, Key, command
 from fakeredis._helpers import SimpleError
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
-from fakeredis.geo import distance, geo_encode, geo_decode
+from fakeredis.geo import distance, geo_decode, geo_encode
 from fakeredis.model import ZSet
 
 _UNIT_TO_M = {b"km": 0.001, b"mi": 0.000621371, b"ft": 3.28084, b"m": 1}
@@ -29,7 +31,7 @@ def translate_meters_to_unit(unit_arg: bytes) -> float:
 GeoResult = namedtuple("GeoResult", "name long lat hash distance")
 
 
-def _parse_results(items: List[GeoResult], withcoord: bool, withdist: bool) -> List[Any]:
+def _parse_results(items: list[GeoResult], withcoord: bool, withdist: bool) -> list[Any]:
     """Parse list of GeoResults to redis response
     :param withcoord: include coordinates in response
     :param withdist: include distance in response
@@ -57,7 +59,7 @@ def _find_near(
     count: int,
     count_any: bool,
     desc: bool,
-) -> List[GeoResult]:
+) -> list[GeoResult]:
     """Find items within area (lat,long)+radius
     :param zset: list of items to check
     :param lat: latitude
@@ -84,7 +86,7 @@ def _find_near(
 
 
 class GeoCommandsMixin(CommandsMixinBase):
-    def _store_geo_results(self, item_name: bytes, geo_results: List[GeoResult], scoredist: bool) -> int:
+    def _store_geo_results(self, item_name: bytes, geo_results: list[GeoResult], scoredist: bool) -> int:
         db_item = CommandItem(item_name, self._db, item=self._db.get(item_name), default=ZSet())
         db_item.value = ZSet()
         for item in geo_results:
@@ -93,10 +95,8 @@ class GeoCommandsMixin(CommandsMixinBase):
         db_item.writeback()
         return len(geo_results)
 
-    def _georadius(
-        self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes
-    ) -> Union[List[bytes], int]:
-        (withcoord, withdist, withhash, count, count_any, desc, store, storedist), left_args = extract_args(
+    def _georadius(self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes) -> list[bytes] | int:
+        (withcoord, withdist, _withhash, count, count_any, desc, store, storedist), _left_args = extract_args(
             args,
             ("withcoord", "withdist", "withhash", "+count", "any", "desc", "*store", "*storedist"),
             error_on_unexpected=False,
@@ -104,7 +104,7 @@ class GeoCommandsMixin(CommandsMixinBase):
         )
         count = count or sys.maxsize
         conv = translate_meters_to_unit(args[0]) if len(args) >= 1 else 1
-        geo_results: List[GeoResult] = _find_near(key.value, lat, long, radius, conv, count, count_any, desc)
+        geo_results: list[GeoResult] = _find_near(key.value, lat, long, radius, conv, count, count_any, desc)
 
         if store:
             self._store_geo_results(store, geo_results, scoredist=False)
@@ -131,9 +131,9 @@ class GeoCommandsMixin(CommandsMixinBase):
                 _GEO_LONGTITUDE_MIN <= long <= _GEO_LONGTITUDE_MAX and _GEO_LATITUDE_MIN <= lat <= _GEO_LATITUDE_MAX
             ):
                 raise SimpleError(msgs.GEO_INVALID_COORDINATE_MSG.format(f"{long:f}", f"{lat:f}"))
-            if (name in zset and not xx) or (name not in zset and not nx):
-                if zset.add(name, geo_encode(lat, long, 10)):
-                    changed_items += 1
+            should_add = (name in zset and not xx) or (name not in zset and not nx)
+            if should_add and zset.add(name, geo_encode(lat, long, 10)):
+                changed_items += 1
         if changed_items:
             key.updated()
         if ch:
@@ -141,19 +141,19 @@ class GeoCommandsMixin(CommandsMixinBase):
         return len(zset) - old_len
 
     @command(name="GEOHASH", fixed=(Key(ZSet), bytes), repeat=(bytes,))
-    def geohash(self, key: CommandItem, *members: bytes) -> List[Union[bytes, None]]:
+    def geohash(self, key: CommandItem, *members: bytes) -> list[bytes | None]:
         hashes = map(key.value.get, members)
-        geohash_list: List[Union[bytes, None]] = [((x + "0").encode() if x is not None else x) for x in hashes]
+        geohash_list: list[bytes | None] = [((x + "0").encode() if x is not None else x) for x in hashes]
         return geohash_list
 
     @command(name="GEOPOS", fixed=(Key(ZSet), bytes), repeat=(bytes,))
-    def geopos(self, key: CommandItem, *members: bytes) -> List[Optional[List[float]]]:
+    def geopos(self, key: CommandItem, *members: bytes) -> list[list[float] | None]:
         gospositions = (geo_decode(x) if x is not None else x for x in map(key.value.get, members))
         res = [([x[1], x[0]] if x is not None else None) for x in gospositions]
         return res
 
     @command(name="GEODIST", fixed=(Key(ZSet), bytes, bytes), repeat=(bytes,))
-    def geodist(self, key: CommandItem, m1: bytes, m2: bytes, *args: bytes) -> Optional[float]:
+    def geodist(self, key: CommandItem, m1: bytes, m2: bytes, *args: bytes) -> float | None:
         geohashes = [key.value.get(m1), key.value.get(m2)]
         if any(elem is None for elem in geohashes):
             return None
@@ -163,8 +163,8 @@ class GeoCommandsMixin(CommandsMixinBase):
         return res * unit
 
     @command(name="GEORADIUS_RO", fixed=(Key(ZSet), Float, Float, Float), repeat=(bytes,))
-    def georadius_ro(self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes) -> List[Any]:
-        (withcoord, withdist, withhash, count, count_any, desc), left_args = extract_args(
+    def georadius_ro(self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes) -> list[Any]:
+        (withcoord, withdist, _withhash, count, count_any, desc), _left_args = extract_args(
             args,
             ("withcoord", "withdist", "withhash", "+count", "any", "desc"),
             error_on_unexpected=False,
@@ -178,27 +178,23 @@ class GeoCommandsMixin(CommandsMixinBase):
         return ret
 
     @command(name="GEORADIUS", fixed=(Key(ZSet), Float, Float, Float), repeat=(bytes,))
-    def georadius(
-        self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes
-    ) -> Union[List[bytes], int]:
+    def georadius(self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes) -> list[bytes] | int:
         return self._georadius(key, long, lat, radius, *args)
 
     @command(name="GEORADIUSBYMEMBER", fixed=(Key(ZSet), bytes, Float), repeat=(bytes,))
-    def georadiusbymember(
-        self, key: CommandItem, member_name: bytes, radius: float, *args: bytes
-    ) -> Union[List[bytes], int]:
+    def georadiusbymember(self, key: CommandItem, member_name: bytes, radius: float, *args: bytes) -> list[bytes] | int:
         member_score = key.value.get(member_name)
         lat, long, _, _ = geo_decode(member_score)
         return self._georadius(key, long, lat, radius, *args)
 
     @command(name="GEORADIUSBYMEMBER_RO", fixed=(Key(ZSet), bytes, Float), repeat=(bytes,))
-    def georadiusbymember_ro(self, key: CommandItem, member_name: bytes, radius: float, *args: float) -> List[Any]:
+    def georadiusbymember_ro(self, key: CommandItem, member_name: bytes, radius: float, *args: float) -> list[Any]:
         member_score = key.value.get(member_name)
         lat, long, _, _ = geo_decode(member_score)
         return self.georadius_ro(key, long, lat, radius, *args)  # type: ignore[no-any-return]
 
     @command(name="GEOSEARCH", fixed=(Key(ZSet),), repeat=(bytes,))
-    def geosearch(self, key: CommandItem, *args: bytes) -> List[Any]:
+    def geosearch(self, key: CommandItem, *args: bytes) -> list[Any]:
         (frommember, (long, lat), radius), left_args = extract_args(
             args,
             ("*frommember", "..fromlonlat", ".byradius"),
@@ -215,7 +211,7 @@ class GeoCommandsMixin(CommandsMixinBase):
             return self.georadius_ro(key, long, lat, radius, *left_args)  # type: ignore
 
     @command(name="GEOSEARCHSTORE", fixed=(bytes, Key(ZSet)), repeat=(bytes,))
-    def geosearchstore(self, dst: bytes, src: CommandItem, *args: bytes) -> List[Any]:
+    def geosearchstore(self, dst: bytes, src: CommandItem, *args: bytes) -> list[Any]:
         (frommember, (long, lat), radius, storedist), left_args = extract_args(
             args,
             ("*frommember", "..fromlonlat", ".byradius", "storedist"),

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -1,13 +1,14 @@
-import random
-from typing import Callable, Dict, List, Any, Optional, Sequence, Union, cast
+from __future__ import annotations
 
 import math
+import random
+from collections.abc import Sequence
+from typing import Any, Callable, cast
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import command, Key, Int, Float, CommandItem
-from fakeredis._helpers import SimpleError, OK, casematch, SimpleString
-from fakeredis._helpers import current_time
+from fakeredis._commands import CommandItem, Float, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch, current_time
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import Hash
 
@@ -20,7 +21,7 @@ class HashCommandsMixin(CommandsMixinBase):
         bytes,
     ]
     _encodefloat: Callable[[float, bool], bytes]
-    _scan: Callable[[Sequence[bytes], int, bytes], List[Union[bytes, List[bytes]]]]
+    _scan: Callable[[Sequence[bytes], int, bytes], list[bytes | list[bytes]]]
     add_subkey_event: Callable[[bytes, bytes, Sequence[bytes]], None]
 
     def _hset(self, key: CommandItem, *args: bytes) -> int:
@@ -54,7 +55,7 @@ class HashCommandsMixin(CommandsMixinBase):
         return key.value.get(field)
 
     @command((Key(Hash),))
-    def hgetall(self, key: CommandItem) -> Dict[bytes, bytes]:
+    def hgetall(self, key: CommandItem) -> dict[bytes, bytes]:
         hash_val: Hash = key.value
         return hash_val.getall()
 
@@ -80,7 +81,7 @@ class HashCommandsMixin(CommandsMixinBase):
         return encoded
 
     @command((Key(Hash),))
-    def hkeys(self, key: CommandItem) -> List[bytes]:
+    def hkeys(self, key: CommandItem) -> list[bytes]:
         return list(key.value.keys())
 
     @command((Key(Hash),))
@@ -88,7 +89,7 @@ class HashCommandsMixin(CommandsMixinBase):
         return len(key.value)
 
     @command((Key(Hash), bytes), (bytes,))
-    def hmget(self, key: CommandItem, *fields: bytes) -> List[bytes]:
+    def hmget(self, key: CommandItem, *fields: bytes) -> list[bytes]:
         return [key.value.get(field) for field in fields]
 
     @command((Key(Hash), bytes, bytes), (bytes, bytes))
@@ -97,12 +98,12 @@ class HashCommandsMixin(CommandsMixinBase):
         return OK
 
     @command((Key(Hash), Int), (bytes,))
-    def hscan(self, key: CommandItem, cursor: int, *args: bytes) -> List[Any]:
+    def hscan(self, key: CommandItem, cursor: int, *args: bytes) -> list[Any]:
         no_values = any(casematch(arg, b"novalues") for arg in args)
         scan_args = tuple(arg for arg in args if not casematch(arg, b"novalues")) if no_values else args
         scan_result = self._scan(key.value, cursor, *scan_args)
         result_cursor = scan_result[0]
-        keys: List[bytes] = cast(List[bytes], scan_result[1])
+        keys: list[bytes] = cast(list[bytes], scan_result[1])
         if no_values:
             return [result_cursor, keys]
         items = []
@@ -126,11 +127,11 @@ class HashCommandsMixin(CommandsMixinBase):
         return len(key.value.get(field, b""))
 
     @command((Key(Hash),))
-    def hvals(self, key: CommandItem) -> List[bytes]:
+    def hvals(self, key: CommandItem) -> list[bytes]:
         return list(key.value.values())
 
     @command(name="HRANDFIELD", fixed=(Key(Hash),), repeat=(bytes,))
-    def hrandfield(self, key: CommandItem, *args: bytes) -> Union[List[List[str]], List[str], None]:
+    def hrandfield(self, key: CommandItem, *args: bytes) -> list[list[str]] | list[str] | None:
         if len(args) > 2:
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         if key.value is None or len(key.value) == 0:
@@ -154,7 +155,7 @@ class HashCommandsMixin(CommandsMixinBase):
             res = [t[0] for t in res]
         return res
 
-    def _hexpire(self, key: CommandItem, when_ms: int, *args: bytes, command: str = "hexpire") -> List[int]:
+    def _hexpire(self, key: CommandItem, when_ms: int, *args: bytes, command: str = "hexpire") -> list[int]:
         # Deal with input arguments
         (nx, xx, gt, lt), left_args = extract_args(
             args, ("nx", "xx", "gt", "lt"), left_from_first_unexpected=True, error_on_unexpected=False
@@ -167,8 +168,8 @@ class HashCommandsMixin(CommandsMixinBase):
             return [-2] * len(fields)
         # process command
         res = []
-        expired_fields: List[bytes] = []
-        deleted_fields: List[bytes] = []
+        expired_fields: list[bytes] = []
+        deleted_fields: list[bytes] = []
         for field in fields:
             if field not in hash_val:
                 res.append(-2)
@@ -189,7 +190,7 @@ class HashCommandsMixin(CommandsMixinBase):
         self.add_subkey_event(b"hdel", key.key, deleted_fields)
         return res
 
-    def _get_expireat(self, command: bytes, key: CommandItem, *args: bytes) -> List[int]:
+    def _get_expireat(self, command: bytes, key: CommandItem, *args: bytes) -> list[int]:
         fields = _get_fields(args, command=command.decode().lower())
         hash_val: Hash = key.value
         if hash_val is None:
@@ -207,30 +208,30 @@ class HashCommandsMixin(CommandsMixinBase):
         return res
 
     @command(name="HEXPIRE", fixed=(Key(Hash), Int), repeat=(bytes,))
-    def hexpire(self, key: CommandItem, seconds: int, *args: bytes) -> List[int]:
+    def hexpire(self, key: CommandItem, seconds: int, *args: bytes) -> list[int]:
         if seconds < 0:
             raise SimpleError(msgs.HEXPIRE_INVALID_TIME_MSG)
         when_ms = current_time() + seconds * 1000
         return self._hexpire(key, when_ms, *args, command="hexpire")
 
     @command(name="HPEXPIRE", fixed=(Key(Hash), Int), repeat=(bytes,))
-    def hpexpire(self, key: CommandItem, milliseconds: int, *args: bytes) -> List[int]:
+    def hpexpire(self, key: CommandItem, milliseconds: int, *args: bytes) -> list[int]:
         if milliseconds < 0:
             raise SimpleError(msgs.HEXPIRE_INVALID_TIME_MSG)
         when_ms = current_time() + milliseconds
         return self._hexpire(key, when_ms, *args, command="hpexpire")
 
     @command(name="HEXPIREAT", fixed=(Key(Hash), Int), repeat=(bytes,))
-    def hexpireat(self, key: CommandItem, unix_time_seconds: int, *args: bytes) -> List[int]:
+    def hexpireat(self, key: CommandItem, unix_time_seconds: int, *args: bytes) -> list[int]:
         when_ms = unix_time_seconds * 1000
         return self._hexpire(key, when_ms, *args, command="hexpireat")
 
     @command(name="HPEXPIREAT", fixed=(Key(Hash), Int), repeat=(bytes,))
-    def hpexpireat(self, key: CommandItem, unix_time_ms: int, *args: bytes) -> List[int]:
+    def hpexpireat(self, key: CommandItem, unix_time_ms: int, *args: bytes) -> list[int]:
         return self._hexpire(key, unix_time_ms, *args, command="hpexpireat")
 
     @command(name="HPERSIST", fixed=(Key(Hash),), repeat=(bytes,))
-    def hpersist(self, key: CommandItem, *args: bytes) -> List[int]:
+    def hpersist(self, key: CommandItem, *args: bytes) -> list[int]:
         fields = _get_fields(args, command="hpersist")
         hash_val: Hash = key.value
         res = []
@@ -250,29 +251,29 @@ class HashCommandsMixin(CommandsMixinBase):
     @command(
         name="HEXPIRETIME", fixed=(Key(Hash),), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE, server_types=("redis",)
     )
-    def hexpiretime(self, key: CommandItem, *args: bytes) -> List[int]:
+    def hexpiretime(self, key: CommandItem, *args: bytes) -> list[int]:
         res = self._get_expireat(b"HEXPIRETIME", key, *args)
         return [(i // 1000 if i > 0 else i) for i in res]
 
     @command(name="HPEXPIRETIME", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
-    def hpexpiretime(self, key: CommandItem, *args: bytes) -> List[int]:
+    def hpexpiretime(self, key: CommandItem, *args: bytes) -> list[int]:
         res = self._get_expireat(b"HPEXPIRETIME", key, *args)
         return res
 
     @command(name="HTTL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
-    def httl(self, key: CommandItem, *args: bytes) -> List[int]:
+    def httl(self, key: CommandItem, *args: bytes) -> list[int]:
         curr_expireat_ms = self._get_expireat(b"HTTL", key, *args)
         curr_time_ms = current_time()
         return [((i - curr_time_ms) // 1000) if i > 0 else i for i in curr_expireat_ms]
 
     @command(name="HPTTL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
-    def hpttl(self, key: CommandItem, *args: bytes) -> List[int]:
+    def hpttl(self, key: CommandItem, *args: bytes) -> list[int]:
         curr_expireat_ms = self._get_expireat(b"HPTTL", key, *args)
         curr_time_ms = current_time()
         return [(i - curr_time_ms) if i > 0 else i for i in curr_expireat_ms]
 
     @command(name="HGETDEL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
-    def hgetdel(self, key: CommandItem, *args: bytes) -> List[Any]:
+    def hgetdel(self, key: CommandItem, *args: bytes) -> list[Any]:
         fields = _get_fields(args, command="hgetdel")
         hash_val: Hash = key.value
         res = [hash_val.pop(field) for field in fields]
@@ -297,9 +298,9 @@ class HashCommandsMixin(CommandsMixinBase):
 
         when_ms = _get_when_ms(ex, px, exat, pxat)
         res = []
-        persisted_fields: List[bytes] = []
-        expired_fields: List[bytes] = []
-        deleted_fields: List[bytes] = []
+        persisted_fields: list[bytes] = []
+        expired_fields: list[bytes] = []
+        deleted_fields: list[bytes] = []
         for field in fields:
             res.append(hash_val.get(field))
             if field not in hash_val:
@@ -337,9 +338,9 @@ class HashCommandsMixin(CommandsMixinBase):
         if fnx and len(field_keys - hash_val.getall().keys()) < len(field_keys):
             return 0
         res = 0
-        set_fields: List[bytes] = []
-        expired_fields: List[bytes] = []
-        deleted_fields: List[bytes] = []
+        set_fields: list[bytes] = []
+        expired_fields: list[bytes] = []
+        deleted_fields: list[bytes] = []
         for i in range(0, len(field_vals), 2):
             field, value = field_vals[i], field_vals[i + 1]
             hash_val[field] = value
@@ -367,7 +368,7 @@ def _get_fields(args: Sequence[bytes], with_values: bool = False, command: str =
     return fields
 
 
-def _get_when_ms(ex: Optional[int], px: Optional[int], exat: Optional[int], pxat: Optional[int]) -> Optional[int]:
+def _get_when_ms(ex: int | None, px: int | None, exat: int | None, pxat: int | None) -> int | None:
     if any(value is not None and value < 0 for value in (ex, px, exat, pxat)):
         raise SimpleError(msgs.HEXPIRE_INVALID_TIME_MSG)
     if ex is not None:

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import random
 from collections.abc import Sequence
-from typing import Any, Callable, cast
+from typing import Any, Callable, List, cast
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
@@ -103,7 +103,7 @@ class HashCommandsMixin(CommandsMixinBase):
         scan_args = tuple(arg for arg in args if not casematch(arg, b"novalues")) if no_values else args
         scan_result = self._scan(key.value, cursor, *scan_args)
         result_cursor = scan_result[0]
-        keys: list[bytes] = cast(list[bytes], scan_result[1])
+        keys: list[bytes] = cast(List[bytes], scan_result[1])
         if no_values:
             return [result_cursor, keys]
         items = []

--- a/fakeredis/commands_mixins/list_mixin.py
+++ b/fakeredis/commands_mixins/list_mixin.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import functools
-from typing import Any, Callable, List, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Any, Callable
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args, parse_mpop_args
@@ -8,7 +11,7 @@ from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 
 
-def _list_pop_count(get_slice: Callable[[int], slice], key: CommandItem, count: int) -> Optional[List[bytes]]:
+def _list_pop_count(get_slice: Callable[[int], slice], key: CommandItem, count: int) -> list[bytes] | None:
     if not key:
         return None
     elif type(key.value) is not list:
@@ -20,7 +23,7 @@ def _list_pop_count(get_slice: Callable[[int], slice], key: CommandItem, count: 
     return ret
 
 
-def _list_pop(get_slice: Callable[[int], slice], key: CommandItem, *args: bytes) -> Optional[Union[bytes, List[bytes]]]:
+def _list_pop(get_slice: Callable[[int], slice], key: CommandItem, *args: bytes) -> bytes | list[bytes] | None:
     """Implements lpop and rpop.
 
     `get_slice` must take a count and return a slice expression for the range to pop.
@@ -41,11 +44,9 @@ def _list_pop(get_slice: Callable[[int], slice], key: CommandItem, *args: bytes)
 
 
 class ListCommandsMixin(CommandsMixinBase):
-    _blocking: Callable[[Optional[Union[float, int]], Callable[[bool], Any]], Any]
+    _blocking: Callable[[float | int | None, Callable[[bool], Any]], Any]
 
-    def _bpop_pass(
-        self, keys: List[bytes], op: Callable[[List[bytes]], bytes], first_pass: bool
-    ) -> Optional[List[bytes]]:
+    def _bpop_pass(self, keys: list[bytes], op: Callable[[list[bytes]], bytes], first_pass: bool) -> list[bytes] | None:
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
             if not isinstance(item.value, list):
@@ -60,7 +61,7 @@ class ListCommandsMixin(CommandsMixinBase):
                 return [key, ret]
         return None
 
-    def _bpop(self, args: Any, op: Callable[[List[bytes]], bytes]) -> Any:
+    def _bpop(self, args: Any, op: Callable[[list[bytes]], bytes]) -> Any:
         keys = args[:-1]
         timeout = Timeout.decode(args[-1])
         return self._blocking(timeout, functools.partial(self._bpop_pass, keys, op))
@@ -160,14 +161,14 @@ class ListCommandsMixin(CommandsMixinBase):
         return self._blocking(timeout, functools.partial(self._lmove, first_list, second_list, src, dst))
 
     @command(fixed=(Key(),), repeat=(bytes,))
-    def lpop(self, key: CommandItem, *args: bytes) -> Optional[Union[bytes, List[bytes]]]:
+    def lpop(self, key: CommandItem, *args: bytes) -> bytes | list[bytes] | None:
         return _list_pop(lambda count: slice(None, count), key, *args)
 
-    def _lmpop(self, keys: Sequence[bytes], count: int, direction_left: bool, first_pass: bool) -> Optional[List[Any]]:
+    def _lmpop(self, keys: Sequence[bytes], count: int, direction_left: bool, first_pass: bool) -> list[Any] | None:
         if direction_left:
-            op = lambda count: slice(None, count)  # noqa:E731
+            op = lambda count: slice(None, count)
         else:
-            op = lambda count: slice(None, -count - 1, -1)  # noqa:E731
+            op = lambda count: slice(None, -count - 1, -1)
 
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
@@ -177,7 +178,7 @@ class ListCommandsMixin(CommandsMixinBase):
         return None
 
     @command(fixed=(Int,), repeat=(bytes,))
-    def lmpop(self, numkeys: int, *args: bytes) -> Optional[List[Any]]:
+    def lmpop(self, numkeys: int, *args: bytes) -> list[Any] | None:
         keys, count, left = parse_mpop_args("lmpop", numkeys, args, ("left", "right"))
         return self._lmpop(keys, count, left, False)
 
@@ -243,7 +244,7 @@ class ListCommandsMixin(CommandsMixinBase):
     @command((Key(list), Int, Int))
     def ltrim(self, key: CommandItem, start: int, stop: int) -> SimpleString:
         if key:
-            end: Optional[int] = None if stop == -1 else stop + 1
+            end: int | None = None if stop == -1 else stop + 1
             new_value = key.value[start:end]
             # Redis signals the key as modified even for a no-op trim (see test_watch_when_ltrim_does_not_change_value),
             # so always update.
@@ -251,7 +252,7 @@ class ListCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(fixed=(Key(),), repeat=(bytes,))
-    def rpop(self, key: CommandItem, *args: bytes) -> Optional[Union[bytes, List[bytes]]]:
+    def rpop(self, key: CommandItem, *args: bytes) -> bytes | list[bytes] | None:
         return _list_pop(lambda count: slice(None, -count - 1, -1), key, *args)
 
     @command((Key(list, None), Key(list)))
@@ -274,7 +275,7 @@ class ListCommandsMixin(CommandsMixinBase):
         return self.rpush(key, *values)
 
     @command(fixed=(Key(list), bytes), repeat=(bytes,))
-    def lpos(self, key: CommandItem, elem: bytes, *args: bytes) -> Union[None, int, List[int]]:
+    def lpos(self, key: CommandItem, elem: bytes, *args: bytes) -> None | int | list[int]:
         (rank, count, maxlen), _ = extract_args(
             args,
             (
@@ -294,7 +295,7 @@ class ListCommandsMixin(CommandsMixinBase):
         rank = abs(rank)
         parse_count = len(key.value) if count == 0 else (count or 1)
         maxlen = maxlen or len(key.value)
-        res: List[int] = []
+        res: list[int] = []
         comparisons = 0
         while 0 <= ind <= len(key.value) - 1 and len(res) < parse_count and comparisons < maxlen:
             comparisons += 1

--- a/fakeredis/commands_mixins/pubsub_mixin.py
+++ b/fakeredis/commands_mixins/pubsub_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import Any, Callable
 

--- a/fakeredis/commands_mixins/pubsub_mixin.py
+++ b/fakeredis/commands_mixins/pubsub_mixin.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict, Callable, List, Iterable
+from collections.abc import Iterable
+from typing import Any, Callable
 
 from fakeredis import _msgs as msgs
 from fakeredis._commands import command
-from fakeredis._helpers import NoResponse, compile_pattern, SimpleError
+from fakeredis._helpers import NoResponse, SimpleError, compile_pattern
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 
 
@@ -10,10 +11,10 @@ class PubSubCommandsMixin(CommandsMixinBase):
     put_response: Callable[[Any], None]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super(PubSubCommandsMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._pubsub = 0  # Count of subscriptions
 
-    def _subscribe(self, channels: Iterable[bytes], subscribers: Dict[bytes, Any], mtype: bytes) -> NoResponse:
+    def _subscribe(self, channels: Iterable[bytes], subscribers: dict[bytes, Any], mtype: bytes) -> NoResponse:
         for channel in channels:
             subs = subscribers[channel]
             if self not in subs:
@@ -23,7 +24,7 @@ class PubSubCommandsMixin(CommandsMixinBase):
             self.put_response(msg)
         return NoResponse()
 
-    def _unsubscribe(self, channels: Iterable[bytes], subscribers: Dict[bytes, Any], mtype: bytes) -> NoResponse:
+    def _unsubscribe(self, channels: Iterable[bytes], subscribers: dict[bytes, Any], mtype: bytes) -> NoResponse:
         if not channels:
             channels = []
             for channel, subs in subscribers.items():
@@ -40,7 +41,7 @@ class PubSubCommandsMixin(CommandsMixinBase):
             self.put_response(msg)
         return NoResponse()
 
-    def _numsub(self, subscribers: Dict[bytes, Any], *channels: bytes) -> List[Any]:
+    def _numsub(self, subscribers: dict[bytes, Any], *channels: bytes) -> list[Any]:
         tuples_list = [(ch, len(subscribers.get(ch, []))) for ch in channels]
         return [item for sublist in tuples_list for item in sublist]
 
@@ -106,7 +107,7 @@ class PubSubCommandsMixin(CommandsMixinBase):
     def pubsub_numpat(self, *_: Any) -> int:
         return len(self._server.psubscribers)
 
-    def _channels(self, subscribers_dict: Dict[bytes, Any], *patterns: bytes) -> List[bytes]:
+    def _channels(self, subscribers_dict: dict[bytes, Any], *patterns: bytes) -> list[bytes]:
         channels = list(subscribers_dict.keys())
         if len(patterns) > 0:
             regex = compile_pattern(patterns[0])
@@ -114,19 +115,19 @@ class PubSubCommandsMixin(CommandsMixinBase):
         return channels
 
     @command(name="PUBSUB CHANNELS", fixed=(), repeat=(bytes,))
-    def pubsub_channels(self, *args: bytes) -> List[bytes]:
+    def pubsub_channels(self, *args: bytes) -> list[bytes]:
         return self._channels(self._server.subscribers, *args)
 
     @command(name="PUBSUB SHARDCHANNELS", fixed=(), repeat=(bytes,))
-    def pubsub_shardchannels(self, *args: bytes) -> List[bytes]:
+    def pubsub_shardchannels(self, *args: bytes) -> list[bytes]:
         return self._channels(self._server.ssubscribers, *args)
 
     @command(name="PUBSUB NUMSUB", fixed=(), repeat=(bytes,))
-    def pubsub_numsub(self, *args: bytes) -> List[Any]:
+    def pubsub_numsub(self, *args: bytes) -> list[Any]:
         return self._numsub(self._server.subscribers, *args)
 
     @command(name="PUBSUB SHARDNUMSUB", fixed=(), repeat=(bytes,))
-    def pubsub_shardnumsub(self, *args: bytes) -> List[Any]:
+    def pubsub_shardnumsub(self, *args: bytes) -> list[Any]:
         return self._numsub(self._server.ssubscribers, *args)
 
     @command(name="PUBSUB", fixed=())
@@ -134,7 +135,7 @@ class PubSubCommandsMixin(CommandsMixinBase):
         raise SimpleError(msgs.WRONG_ARGS_MSG6.format("pubsub"))
 
     @command(name="PUBSUB HELP", fixed=())
-    def pubsub_help(self, *args: Any) -> List[bytes]:
+    def pubsub_help(self, *args: Any) -> list[bytes]:
         if self.version >= (7,):
             help_strings = [
                 "PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",

--- a/fakeredis/commands_mixins/scripting_mixin.py
+++ b/fakeredis/commands_mixins/scripting_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import hashlib
 import importlib
@@ -5,7 +7,7 @@ import itertools
 import json
 import logging
 import os
-from typing import Any, AnyStr, Callable, List, Optional, Set, Tuple
+from typing import Any, AnyStr, Callable
 
 import lupa
 
@@ -52,12 +54,12 @@ _lua_cjson_null = object()  # sentinel value
 
 
 class ScriptingCommandsMixin(CommandsMixinBase):
-    _name_to_func: Callable[[str], Tuple[Optional[Callable[..., Any]], Signature]]
-    _run_command: Callable[[Callable[..., Any], Signature, List[Any], bool], Any]
+    _name_to_func: Callable[[str], tuple[Callable[..., Any] | None, Signature]]
+    _run_command: Callable[[Callable[..., Any], Signature, list[Any], bool], Any]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.load_lua_modules: Set[str] = kwargs.pop("lua_modules", None) or set()
-        super(ScriptingCommandsMixin, self).__init__(*args, **kwargs)
+        self.load_lua_modules: set[str] = kwargs.pop("lua_modules", None) or set()
+        super().__init__(*args, **kwargs)
 
     def _convert_redis_result(self, lua_runtime: Any, result: Any) -> Any:
         if isinstance(result, (bytes, int)):
@@ -80,7 +82,7 @@ class ScriptingCommandsMixin(CommandsMixinBase):
                 raise SimpleError(msgs.WRONG_ARGS_MSG7)
             raise result
         else:
-            raise RuntimeError(f"Unexpected return type from redis: {type(result)}")
+            raise TypeError(f"Unexpected return type from redis: {type(result)}")
 
     def _convert_lua_result(self, result: Any, nested: bool = True) -> Any:
         if LUA_MODULE.lua_type(result) == "table":
@@ -111,7 +113,7 @@ class ScriptingCommandsMixin(CommandsMixinBase):
             return 1 if result else None
         return result
 
-    def _lua_redis_call(self, lua_runtime: Any, expected_globals: Set[Any], op: bytes, *args: Any) -> Any:
+    def _lua_redis_call(self, lua_runtime: Any, expected_globals: set[Any], op: bytes, *args: Any) -> Any:
         # Check if we've set any global variables before making any change.
         _check_for_lua_globals(lua_runtime, expected_globals)
         func, sig = self._name_to_func(decode_command_bytes(op))
@@ -122,7 +124,7 @@ class ScriptingCommandsMixin(CommandsMixinBase):
         result = self._convert_redis_result(lua_runtime, result)
         return result
 
-    def _lua_redis_pcall(self, lua_runtime: Any, expected_globals: Set[Any], op: bytes, *args: Any) -> Any:
+    def _lua_redis_pcall(self, lua_runtime: Any, expected_globals: set[Any], op: bytes, *args: Any) -> Any:
         try:
             return self._lua_redis_call(lua_runtime, expected_globals, op, *args)
         except Exception as ex:
@@ -134,7 +136,7 @@ class ScriptingCommandsMixin(CommandsMixinBase):
             s._lua_runtime = LUA_MODULE.LuaRuntime(encoding=None, unpack_returned_tuples=True)
             lua_runtime = s._lua_runtime
 
-            valid_modules: Set[str] = set()
+            valid_modules: set[str] = set()
             for module in self.load_lua_modules:
                 try:
                     lua_runtime.require(module.encode())
@@ -292,7 +294,7 @@ class ScriptingCommandsMixin(CommandsMixinBase):
         return sha1
 
     @command(name="SCRIPT EXISTS", fixed=(), repeat=(bytes,), flags=msgs.FLAG_NO_SCRIPT)
-    def script_exists(self, *args: bytes) -> List[int]:
+    def script_exists(self, *args: bytes) -> list[int]:
         if self.version >= (7,) and len(args) == 0:
             raise SimpleError(msgs.WRONG_ARGS_MSG7)
         return [int(sha1 in self._server.script_cache) for sha1 in args]
@@ -309,7 +311,7 @@ class ScriptingCommandsMixin(CommandsMixinBase):
         raise SimpleError(msgs.BAD_SUBCOMMAND_MSG.format("SCRIPT"))
 
     @command(name="SCRIPT HELP", fixed=())
-    def script_help(self, *args: bytes) -> List[bytes]:
+    def script_help(self, *args: bytes) -> list[bytes]:
         help_strings = [
             "SCRIPT <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
             "DEBUG (YES|SYNC|NO)",
@@ -346,23 +348,23 @@ def _convert_redis_arg(value: Any) -> bytes:
     if type(value) is bytes:
         return value
     elif type(value) in {int, float}:
-        return "{:.17g}".format(value).encode()
+        return f"{value:.17g}".encode()
     else:
         raise SimpleError(msgs.LUA_COMMAND_ARG_MSG)
 
 
-def _check_for_lua_globals(lua_runtime: Any, expected_globals: Set[Any]) -> None:
+def _check_for_lua_globals(lua_runtime: Any, expected_globals: set[Any]) -> None:
     unexpected_globals = set(lua_runtime.globals().keys()) - expected_globals
     if len(unexpected_globals) > 0:
         unexpected = [_ensure_str(var, "utf-8", "replace") for var in unexpected_globals]
         raise SimpleError(msgs.GLOBAL_VARIABLE_MSG.format(", ".join(unexpected)))
 
 
-def _lua_redis_log(lua_runtime: Any, expected_globals: Set[Any], lvl: int, *args: Any) -> None:
+def _lua_redis_log(lua_runtime: Any, expected_globals: set[Any], lvl: int, *args: Any) -> None:
     _check_for_lua_globals(lua_runtime, expected_globals)
     if len(args) < 1:
         raise SimpleError(msgs.REQUIRES_MORE_ARGS_MSG.format("redis.log()", "two"))
-    if lvl not in REDIS_LOG_LEVELS_TO_LOGGING.keys():
+    if lvl not in REDIS_LOG_LEVELS_TO_LOGGING:
         raise SimpleError(msgs.LOG_INVALID_DEBUG_LEVEL_MSG)
     msg = " ".join([x.decode("utf-8") if isinstance(x, bytes) else str(x) for x in args if not isinstance(x, bool)])
     LOGGER.log(REDIS_LOG_LEVELS_TO_LOGGING[lvl], msg)
@@ -406,13 +408,13 @@ def _cjson_lua_to_python(obj: Any) -> Any:
     return {_cjson_lua_to_python(key): _cjson_lua_to_python(value) for key, value in d.items()}
 
 
-def _lua_cjson_encode(lua_runtime: Any, expected_globals: Set[Any], value: Any) -> bytes:
+def _lua_cjson_encode(lua_runtime: Any, expected_globals: set[Any], value: Any) -> bytes:
     _check_for_lua_globals(lua_runtime, expected_globals)
     value = _cjson_lua_to_python(value)
     return json.dumps(value, separators=(",", ":")).encode()
 
 
-def _lua_cjson_decode(lua_runtime: Any, expected_globals: Set[Any], json_str: str) -> Any:
+def _lua_cjson_decode(lua_runtime: Any, expected_globals: set[Any], json_str: str) -> Any:
     _check_for_lua_globals(lua_runtime, expected_globals)
     json_obj = json.loads(json_str)
     json_obj = _cjson_python_to_lua(json_obj)

--- a/fakeredis/commands_mixins/server_mixin.py
+++ b/fakeredis/commands_mixins/server_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from typing import Any
 

--- a/fakeredis/commands_mixins/server_mixin.py
+++ b/fakeredis/commands_mixins/server_mixin.py
@@ -1,11 +1,11 @@
 import time
-from typing import Any, List
+from typing import Any
 
 from fakeredis import _msgs as msgs
-from fakeredis._commands import command, DbIndex
-from fakeredis._helpers import OK, SimpleError, casematch, BGSAVE_STARTED, SimpleString
+from fakeredis._commands import DbIndex, command
+from fakeredis._helpers import BGSAVE_STARTED, OK, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
-from fakeredis.model import get_command_info, get_all_commands_info
+from fakeredis.model import get_all_commands_info, get_command_info
 
 
 class ServerCommandsMixin(CommandsMixinBase):
@@ -46,7 +46,7 @@ class ServerCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(())
-    def time(self) -> List[bytes]:
+    def time(self) -> list[bytes]:
         now_us = round(time.time() * 1_000_000)
         now_s = now_us // 1_000_000
         now_us %= 1_000_000
@@ -61,7 +61,7 @@ class ServerCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="COMMAND INFO", fixed=(), repeat=(bytes,))
-    def command_info(self, *commands: bytes) -> List[Any]:
+    def command_info(self, *commands: bytes) -> list[Any]:
         res = [get_command_info(cmd) for cmd in commands]
         return res
 
@@ -70,6 +70,6 @@ class ServerCommandsMixin(CommandsMixinBase):
         return len(get_all_commands_info())
 
     @command(name="COMMAND", fixed=(), repeat=())
-    def command_(self) -> List[Any]:
+    def command_(self) -> list[Any]:
         res = [get_command_info(cmd) for cmd in get_all_commands_info()]
         return res

--- a/fakeredis/commands_mixins/set_mixin.py
+++ b/fakeredis/commands_mixins/set_mixin.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import random
-from typing import Callable, Any, Optional, List, Union, Sequence
+from collections.abc import Sequence
+from typing import Any, Callable
 
 from fakeredis import _msgs as msgs
-from fakeredis._commands import command, Key, Int, CommandItem
-from fakeredis._helpers import OK, SimpleError, casematch, SimpleString
-from fakeredis.model import ExpiringMembersSet
+from fakeredis._commands import CommandItem, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
+from fakeredis.model import ExpiringMembersSet
 
 
 def _calc_setop(op: Callable[..., Any], stop_if_missing: bool, key: CommandItem, *keys: CommandItem) -> Any:
@@ -26,7 +29,7 @@ def _calc_setop(op: Callable[..., Any], stop_if_missing: bool, key: CommandItem,
 
 
 def _setop(
-    op: Callable[..., Any], stop_if_missing: bool, dst: Optional[CommandItem], key: CommandItem, *keys: CommandItem
+    op: Callable[..., Any], stop_if_missing: bool, dst: CommandItem | None, key: CommandItem, *keys: CommandItem
 ) -> Any:
     """Apply one of SINTER[STORE], SUNION[STORE], SDIFF[STORE].
 
@@ -43,7 +46,7 @@ def _setop(
 
 
 class SetCommandsMixin(CommandsMixinBase):
-    _scan: Callable[[Sequence[bytes], int, bytes], List[Union[bytes, List[bytes]]]]
+    _scan: Callable[[Sequence[bytes], int, bytes], list[bytes | list[bytes]]]
 
     @command((Key(ExpiringMembersSet), bytes), (bytes,))
     def sadd(self, key: CommandItem, *members: bytes) -> int:
@@ -99,11 +102,11 @@ class SetCommandsMixin(CommandsMixinBase):
         return int(member in key.value)
 
     @command((Key(ExpiringMembersSet), bytes), (bytes,))
-    def smismember(self, key: CommandItem, *members: bytes) -> List[int]:
+    def smismember(self, key: CommandItem, *members: bytes) -> list[int]:
         return [self.sismember(key, member) for member in members]
 
     @command((Key(ExpiringMembersSet),))
-    def smembers(self, key: CommandItem) -> List[bytes]:
+    def smembers(self, key: CommandItem) -> list[bytes]:
         return list(key.value)
 
     @command((Key(ExpiringMembersSet, 0), Key(ExpiringMembersSet), bytes))
@@ -119,7 +122,7 @@ class SetCommandsMixin(CommandsMixinBase):
             return 1
 
     @command((Key(ExpiringMembersSet),), (Int,))
-    def spop(self, key: CommandItem, count: Optional[int] = None) -> Union[bytes, List[bytes], None]:
+    def spop(self, key: CommandItem, count: int | None = None) -> bytes | list[bytes] | None:
         if count is None:
             if not key.value:
                 return None
@@ -130,14 +133,14 @@ class SetCommandsMixin(CommandsMixinBase):
         else:
             if count < 0:
                 raise SimpleError(msgs.INDEX_NEGATIVE_ERROR_MSG)
-            items: Union[bytes, List[bytes]] = self.srandmember(key, count)
+            items: bytes | list[bytes] = self.srandmember(key, count)
             for item in items:
                 key.value.remove(item)
                 key.updated()  # Inside the loop because redis special-cases count=0
             return items
 
     @command((Key(ExpiringMembersSet),), (Int,))
-    def srandmember(self, key: CommandItem, count: Optional[int] = None) -> Union[bytes, List[bytes], None]:
+    def srandmember(self, key: CommandItem, count: int | None = None) -> bytes | list[bytes] | None:
         if count is None:
             if not key.value:
                 return None

--- a/fakeredis/commands_mixins/sortedset_mixin.py
+++ b/fakeredis/commands_mixins/sortedset_mixin.py
@@ -5,26 +5,27 @@ import itertools
 import math
 import random
 import sys
-from typing import Union, Optional, List, Tuple, Callable, Any, Dict, Sequence, TypeVar
+from collections.abc import Sequence
+from typing import Any, Callable, TypeVar
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args, parse_mpop_args
 from fakeredis._commands import (
-    command,
-    Key,
-    Int,
-    Float,
-    CommandItem,
-    Timeout,
-    StringTest,
-    fix_range,
     AfterAny,
     BeforeAny,
+    CommandItem,
+    Float,
+    Int,
+    Key,
     RedisType,
+    StringTest,
+    Timeout,
+    command,
+    fix_range,
 )
 from fakeredis._helpers import SimpleError, casematch, null_terminate
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
-from fakeredis.model import ZSet, ExpiringMembersSet
+from fakeredis.model import ExpiringMembersSet, ZSet
 
 SORTED_SET_METHODS = {
     "ZUNIONSTORE": lambda s1, s2: s1 | s2,
@@ -41,13 +42,13 @@ _T = TypeVar("_T")
 class ScoreTest(RedisType):
     """Argument converter for sorted set score endpoints."""
 
-    def __init__(self, value: float, exclusive: bool = False, bytes_val: Optional[bytes] = None):
+    def __init__(self, value: float, exclusive: bool = False, bytes_val: bytes | None = None):
         self.value = value
         self.exclusive = exclusive
         self.bytes_val = bytes_val
 
     @classmethod
-    def decode(cls, value: bytes) -> "ScoreTest":
+    def decode(cls, value: bytes) -> ScoreTest:
         try:
             original_value = value
             exclusive = False
@@ -67,25 +68,25 @@ class ScoreTest(RedisType):
 
     def __str__(self) -> str:
         if self.exclusive:
-            return "({!r}".format(self.value)
+            return f"({self.value!r}"
         else:
             return repr(self.value)
 
     @property
-    def lower_bound(self) -> Tuple[float, Union[AfterAny, BeforeAny]]:
+    def lower_bound(self) -> tuple[float, AfterAny | BeforeAny]:
         return self.value, AfterAny() if self.exclusive else BeforeAny()
 
     @property
-    def upper_bound(self) -> Tuple[float, Union[AfterAny, BeforeAny]]:
+    def upper_bound(self) -> tuple[float, AfterAny | BeforeAny]:
         return self.value, BeforeAny() if self.exclusive else AfterAny()
 
 
 class SortedSetCommandsMixin(CommandsMixinBase):
-    _blocking: Callable[[Optional[Union[float, int]], Callable[[bool], Any]], Any]
+    _blocking: Callable[[float | int | None, Callable[[bool], Any]], Any]
     _scan: Callable[..., Any]
     _encodefloat: Callable[[float, bool], bytes]
 
-    def _zpop(self, key: CommandItem, count: int, reverse: bool, flatten_list: bool) -> List[List[Any]]:
+    def _zpop(self, key: CommandItem, count: int, reverse: bool, flatten_list: bool) -> list[list[Any]]:
         if count < 0:
             raise SimpleError(msgs.INDEX_NEGATIVE_ERROR_MSG)
         zset = key.value
@@ -104,7 +105,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             key.updated()
         return res
 
-    def _bzpop(self, keys: List[bytes], reverse: bool, first_pass: bool) -> Optional[List[Union[bytes, List[bytes]]]]:
+    def _bzpop(self, keys: list[bytes], reverse: bool, first_pass: bool) -> list[bytes | list[bytes]] | None:
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
             temp_res = self._zpop(item, 1, reverse, flatten_list=False)
@@ -113,35 +114,35 @@ class SortedSetCommandsMixin(CommandsMixinBase):
                 return [key, temp_res[0][0], temp_res[0][1]]
         return None
 
-    def _zpop_flatten(self, count: Optional[int]) -> bool:
+    def _zpop_flatten(self, count: int | None) -> bool:
         # RESP2 always returns a flat list. RESP3 returns a flat member/score pair
         # only when no count was given; with an explicit count it returns an array
         # of pairs.
         return self._client_info.protocol_version == 2 or count is None
 
     @command((Key(ZSet),), (Int,))
-    def zpopmin(self, key: CommandItem, count: Optional[int] = None) -> List[Any]:
+    def zpopmin(self, key: CommandItem, count: int | None = None) -> list[Any]:
         return self._zpop(key, 1 if count is None else count, reverse=False, flatten_list=self._zpop_flatten(count))
 
     @command((Key(ZSet),), (Int,))
-    def zpopmax(self, key: CommandItem, count: Optional[int] = None) -> List[Any]:
+    def zpopmax(self, key: CommandItem, count: int | None = None) -> list[Any]:
         return self._zpop(key, 1 if count is None else count, reverse=True, flatten_list=self._zpop_flatten(count))
 
     @command((bytes, bytes), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
-    def bzpopmin(self, *args: bytes) -> Optional[List[List[bytes]]]:
+    def bzpopmin(self, *args: bytes) -> list[list[bytes]] | None:
         keys = args[:-1]
         timeout = Timeout.decode(args[-1])
         return self._blocking(timeout, functools.partial(self._bzpop, keys, False))  # type:ignore
 
     @command((bytes, bytes), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
-    def bzpopmax(self, *args: bytes) -> Optional[List[List[bytes]]]:
+    def bzpopmax(self, *args: bytes) -> list[list[bytes]] | None:
         keys = args[:-1]
         timeout = Timeout.decode(args[-1])
         return self._blocking(timeout, functools.partial(self._bzpop, keys, True))  # type:ignore
 
     @staticmethod
-    def _limit_items(items: List[_T], offset: int, count: int) -> List[_T]:
-        out: List[_T] = []
+    def _limit_items(items: list[_T], offset: int, count: int) -> list[_T]:
+        out: list[_T] = []
         for item in items:
             if offset:  # Note: not offset > 0, to match redis
                 offset -= 1
@@ -152,7 +153,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             out.append(item)
         return out
 
-    def _apply_withscores(self, items: List[Tuple[bytes, bytes]], withscores: bool) -> List[Any]:
+    def _apply_withscores(self, items: list[tuple[bytes, bytes]], withscores: bool) -> list[Any]:
         if withscores:
             if self._client_info.protocol_version == 2:
                 out = []
@@ -165,7 +166,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             return [item[1] for item in items]
 
     @command((Key(ZSet), bytes, bytes), (bytes,))
-    def zadd(self, key: CommandItem, *args: bytes) -> Union[int, float, None]:
+    def zadd(self, key: CommandItem, *args: bytes) -> int | float | None:
         zset = key.value
 
         (nx, xx, ch, incr, gt, lt), left_args = extract_args(
@@ -218,9 +219,8 @@ class SortedSetCommandsMixin(CommandsMixinBase):
                 lt and ((item_name in zset and zset.get(item_name) > item_score) or (not xx and item_name not in zset))
             )
 
-            if update:
-                if zset.add(item_name, item_score):
-                    changed_items += 1
+            if update and zset.add(item_name, item_score):
+                changed_items += 1
 
         if changed_items:
             key.updated()
@@ -265,7 +265,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         withscores: bool,
         offset: int,
         count: int,
-    ) -> List[Any]:
+    ) -> list[Any]:
         zset = key.value
         if reverse:
             _min, _max = _max, _min
@@ -276,7 +276,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
 
     def _zrange(
         self, key: CommandItem, start: ScoreTest, stop: ScoreTest, reverse: bool, withscores: bool, byscore: bool
-    ) -> List[Any]:
+    ) -> list[Any]:
         zset = key.value
         if byscore:
             items = zset.irange_score(start.lower_bound, stop.upper_bound, reverse=reverse)
@@ -293,7 +293,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
 
     def _zrangebylex(
         self, key: CommandItem, _min: StringTest, _max: StringTest, reverse: bool, offset: int, count: int
-    ) -> List[bytes]:
+    ) -> list[bytes]:
         zset = key.value
         if reverse:
             _min, _max = _max, _min
@@ -306,7 +306,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         items = self._limit_items(items, offset, count)
         return items
 
-    def _zrange_args(self, key: CommandItem, start: bytes, stop: bytes, *args: bytes) -> List[Any]:
+    def _zrange_args(self, key: CommandItem, start: bytes, stop: bytes, *args: bytes) -> list[Any]:
         (bylex, byscore, rev, (offset, count), withscores), _ = extract_args(
             args, ("bylex", "byscore", "rev", "++limit", "withscores")
         )
@@ -329,7 +329,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return res
 
     @command((Key(ZSet), bytes, bytes), (bytes,))
-    def zrange(self, key: CommandItem, start: bytes, stop: bytes, *args: bytes) -> List[Any]:
+    def zrange(self, key: CommandItem, start: bytes, stop: bytes, *args: bytes) -> list[Any]:
         return self._zrange_args(key, start, stop, *args)
 
     @command((Key(ZSet), Key(ZSet), bytes, bytes), (bytes,))
@@ -342,40 +342,40 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return len(res)
 
     @command((Key(ZSet), ScoreTest, ScoreTest), (bytes,))
-    def zrevrange(self, key: CommandItem, start: ScoreTest, stop: ScoreTest, *args: bytes) -> List[Any]:
+    def zrevrange(self, key: CommandItem, start: ScoreTest, stop: ScoreTest, *args: bytes) -> list[Any]:
         (withscores, byscore), _ = extract_args(args, ("withscores", "byscore"))
         return self._zrange(key, start, stop, True, withscores, byscore)
 
     @command((Key(ZSet), StringTest, StringTest), (bytes,))
-    def zrangebylex(self, key: CommandItem, _min: StringTest, _max: StringTest, *args: bytes) -> List[bytes]:
+    def zrangebylex(self, key: CommandItem, _min: StringTest, _max: StringTest, *args: bytes) -> list[bytes]:
         ((offset, count),), _ = extract_args(args, ("++limit",))
         offset = offset or 0
         count = -1 if count is None else count
         return self._zrangebylex(key, _min, _max, False, offset, count)
 
     @command((Key(ZSet), StringTest, StringTest), (bytes,))
-    def zrevrangebylex(self, key: CommandItem, _min: StringTest, _max: StringTest, *args: bytes) -> List[bytes]:
+    def zrevrangebylex(self, key: CommandItem, _min: StringTest, _max: StringTest, *args: bytes) -> list[bytes]:
         ((offset, count),), _ = extract_args(args, ("++limit",))
         offset = offset or 0
         count = -1 if count is None else count
         return self._zrangebylex(key, _min, _max, True, offset, count)
 
     @command((Key(ZSet), ScoreTest, ScoreTest), (bytes,))
-    def zrangebyscore(self, key: CommandItem, _min: ScoreTest, _max: ScoreTest, *args: bytes) -> List[Any]:
+    def zrangebyscore(self, key: CommandItem, _min: ScoreTest, _max: ScoreTest, *args: bytes) -> list[Any]:
         (withscores, (offset, count)), _ = extract_args(args, ("withscores", "++limit"))
         offset = offset or 0
         count = -1 if count is None else count
         return self._zrangebyscore(key, _min, _max, False, withscores, offset, count)
 
     @command((Key(ZSet), ScoreTest, ScoreTest), (bytes,))
-    def zrevrangebyscore(self, key: CommandItem, _min: ScoreTest, _max: ScoreTest, *args: bytes) -> List[Any]:
+    def zrevrangebyscore(self, key: CommandItem, _min: ScoreTest, _max: ScoreTest, *args: bytes) -> list[Any]:
         (withscores, (offset, count)), _ = extract_args(args, ("withscores", "++limit"))
         offset = offset or 0
         count = -1 if count is None else count
         return self._zrangebyscore(key, _min, _max, True, withscores, offset, count)
 
     @command(name="ZRANK", fixed=(Key(ZSet), bytes), repeat=(bytes,))
-    def zrank(self, key: CommandItem, member: bytes, *args: bytes) -> Union[None, int, List[Union[int, float]]]:
+    def zrank(self, key: CommandItem, member: bytes, *args: bytes) -> None | int | list[int | float]:
         (withscore,), _ = extract_args(args, ("withscore",))
         try:
             rank: int
@@ -388,7 +388,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             return None
 
     @command(name="ZREVRANK", fixed=(Key(ZSet), bytes), repeat=(bytes,))
-    def zrevrank(self, key: CommandItem, member: bytes, *args: bytes) -> Union[None, int, List[Union[int, float]]]:
+    def zrevrank(self, key: CommandItem, member: bytes, *args: bytes) -> None | int | list[int | float]:
         (withscore,), _ = extract_args(args, ("withscore",))
         try:
             rank: int
@@ -429,7 +429,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return self.zrem(key, *[item[1] for item in items])  # type: ignore[no-any-return]
 
     @command((Key(ZSet), Int), (bytes, bytes))
-    def zscan(self, key: CommandItem, cursor: int, *args: bytes) -> List[Any]:
+    def zscan(self, key: CommandItem, cursor: int, *args: bytes) -> list[Any]:
         new_cursor, ans = self._scan(key.value.items(), cursor, *args)
         flat = []
         for member, score in ans:
@@ -438,7 +438,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return [new_cursor, flat]
 
     @command((Key(ZSet), bytes))
-    def zscore(self, key: CommandItem, member: bytes) -> Optional[float]:
+    def zscore(self, key: CommandItem, member: bytes) -> float | None:
         try:
             score: float = key.value[member]
             return score
@@ -457,7 +457,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         else:
             raise SimpleError(msgs.WRONGTYPE_MSG)
 
-    def _zunioninterdiff(self, func: str, dest: Optional[CommandItem], numkeys: int, *args: bytes) -> Union[ZSet, int]:
+    def _zunioninterdiff(self, func: str, dest: CommandItem | None, numkeys: int, *args: bytes) -> ZSet | int:
         if numkeys < 1:
             raise SimpleError(msgs.ZUNIONSTORE_KEYS_MSG.format(func.lower()))
         if numkeys > len(args):
@@ -493,7 +493,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
 
         # We first build a regular dict and turn it into a ZSet. The reason is subtle: a ZSet won't update a score from
         # -0 to +0 (or vice versa) through assignment, but a regular dict will.
-        out: Dict[bytes, Any] = {}
+        out: dict[bytes, Any] = {}
         # The sort affects the order of floating-point operations.
         # Note that redis uses qsort(1), which has no stability guarantees,
         # so we can't be sure to match it in all cases.
@@ -544,12 +544,12 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return self._zunioninterdiff("ZDIFFSTORE", dest, numkeys, *args)  # type: ignore[return-value]
 
     @command((Int, bytes), (bytes,))
-    def zdiff(self, numkeys: int, *args: bytes) -> List[Any]:
+    def zdiff(self, numkeys: int, *args: bytes) -> list[Any]:
         withscores = casematch(b"withscores", args[-1])
         sets = args[:-1] if withscores else args
         zset_res = self._zunioninterdiff("ZDIFF", None, numkeys, *sets)
         assert isinstance(zset_res, ZSet)
-        out: List[Any]
+        out: list[Any]
         if not withscores:
             out = list(zset_res)
         elif self._client_info.protocol_version == 2:
@@ -559,12 +559,12 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return out
 
     @command((Int, bytes), (bytes,))
-    def zunion(self, numkeys: int, *args: bytes) -> List[Any]:
+    def zunion(self, numkeys: int, *args: bytes) -> list[Any]:
         withscores = casematch(b"withscores", args[-1])
         sets = args[:-1] if withscores else args
         zset_res = self._zunioninterdiff("ZUNION", None, numkeys, *sets)
         assert isinstance(zset_res, ZSet)
-        out: List[Any]
+        out: list[Any]
         if not withscores:
             out = list(zset_res)
         elif self._client_info.protocol_version == 2:
@@ -574,12 +574,12 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return out
 
     @command((Int, bytes), (bytes,))
-    def zinter(self, numkeys: int, *args: bytes) -> List[Any]:
+    def zinter(self, numkeys: int, *args: bytes) -> list[Any]:
         withscores = casematch(b"withscores", args[-1])
         sets = args[:-1] if withscores else args
         zset_res = self._zunioninterdiff("ZINTER", None, numkeys, *sets)
         assert isinstance(zset_res, ZSet)
-        out: List[Any]
+        out: list[Any]
         if not withscores:
             out = list(zset_res)
         elif self._client_info.protocol_version == 2:
@@ -604,7 +604,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return min(limit, len(res))  # type: ignore[arg-type]
 
     @command(name="ZMSCORE", fixed=(Key(ZSet), bytes), repeat=(bytes,))
-    def zmscore(self, key: CommandItem, *members: Union[str, bytes]) -> List[Optional[float]]:
+    def zmscore(self, key: CommandItem, *members: str | bytes) -> list[float | None]:
         """Get the scores associated with the specified members in the sorted set stored at the key.
 
         For every member that does not exist in the sorted set, a nil value is returned.
@@ -613,7 +613,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return list(scores)
 
     @command(name="ZRANDMEMBER", fixed=(Key(ZSet),), repeat=(bytes,))
-    def zrandmember(self, key: CommandItem, *args: bytes) -> Optional[List[Any]]:
+    def zrandmember(self, key: CommandItem, *args: bytes) -> list[Any] | None:
         count, withscores = 1, None
         if len(args) > 0:
             count = Int.decode(args[0])
@@ -639,7 +639,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             res = [list(item) for item in res]
         return res
 
-    def _zmpop(self, keys: Sequence[bytes], count: int, reverse: bool, first_pass: bool) -> Optional[List[Any]]:
+    def _zmpop(self, keys: Sequence[bytes], count: int, reverse: bool, first_pass: bool) -> list[Any] | None:
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
             res = self._zpop(item, count, reverse, flatten_list=False)
@@ -649,12 +649,12 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         return None
 
     @command(fixed=(Int,), repeat=(bytes,))
-    def zmpop(self, numkeys: int, *args: bytes) -> Optional[List[Any]]:
+    def zmpop(self, numkeys: int, *args: bytes) -> list[Any] | None:
         keys, count, reverse = parse_mpop_args("zmpop", numkeys, args, ("max", "min"))
         return self._zmpop(keys, count, reverse, False)
 
     @command(fixed=(Timeout, Int), repeat=(bytes,))
-    def bzmpop(self, timeout: float, numkeys: int, *args: bytes) -> Optional[List[Any]]:
+    def bzmpop(self, timeout: float, numkeys: int, *args: bytes) -> list[Any] | None:
         keys, count, reverse = parse_mpop_args("bzmpop", numkeys, args, ("max", "min"))
         return self._blocking(  # type: ignore[no-any-return]
             timeout,

--- a/fakeredis/commands_mixins/streams_mixin.py
+++ b/fakeredis/commands_mixins/streams_mixin.py
@@ -1,19 +1,21 @@
+from __future__ import annotations
+
 import functools
-from typing import List, Union, Tuple, Callable, Optional, Any, Dict
+from typing import Any, Callable
 
 import fakeredis._msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import Key, command, CommandItem, Int
-from fakeredis._helpers import SimpleError, casematch, OK, current_time, SimpleString, casematch_any
-from fakeredis.model import XStream, StreamRangeTest, StreamGroup, StreamEntryKey
+from fakeredis._commands import CommandItem, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch, casematch_any, current_time
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
+from fakeredis.model import StreamEntryKey, StreamGroup, StreamRangeTest, XStream
 
 
 class StreamsCommandsMixin(CommandsMixinBase):
-    _blocking: Callable[[Optional[Union[float, int]], Callable[[bool], Any]], Any]
+    _blocking: Callable[[float | int | None, Callable[[bool], Any]], Any]
 
     @command(name="XADD", fixed=(Key(),), repeat=(bytes,))
-    def xadd(self, key: CommandItem, *args: bytes) -> Optional[bytes]:
+    def xadd(self, key: CommandItem, *args: bytes) -> bytes | None:
         (nomkstream, limit, maxlen, minid, idmpauto, idmp), left_args = extract_args(
             args, ("nomkstream", "+limit", "~+maxlen", "~minid", "*idmpauto", "**idmp"), error_on_unexpected=False
         )
@@ -31,7 +33,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
             producer_id, idempotent_id = idmp
         if idmpauto is not None:
             producer_id = idmpauto
-        res: Optional[bytes] = stream.add(
+        res: bytes | None = stream.add(
             elements, entry_key=entry_key, producer_id=producer_id, idempotent_id=idempotent_id
         )
         if res is None:
@@ -60,24 +62,24 @@ class StreamsCommandsMixin(CommandsMixinBase):
         return len(key.value)
 
     @command(name="XRANGE", fixed=(Key(XStream), StreamRangeTest, StreamRangeTest), repeat=(bytes,))
-    def xrange(self, key: CommandItem, _min: StreamRangeTest, _max: StreamRangeTest, *args: bytes) -> List[bytes]:
+    def xrange(self, key: CommandItem, _min: StreamRangeTest, _max: StreamRangeTest, *args: bytes) -> list[bytes]:
         (count,), _ = extract_args(args, ("+count",))
         return self._xrange(key.value, _min, _max, False, count)
 
     @command(name="XREVRANGE", fixed=(Key(XStream), StreamRangeTest, StreamRangeTest), repeat=(bytes,))
-    def xrevrange(self, key: CommandItem, _min: StreamRangeTest, _max: StreamRangeTest, *args: bytes) -> List[bytes]:
+    def xrevrange(self, key: CommandItem, _min: StreamRangeTest, _max: StreamRangeTest, *args: bytes) -> list[bytes]:
         (count,), _ = extract_args(args, ("+count",))
         return self._xrange(key.value, _max, _min, True, count)
 
     @command(name="XREAD", fixed=(bytes,), repeat=(bytes,), flags=msgs.FLAG_SKIP_CONVERT_TO_RESP2)
-    def xread(self, *args: bytes) -> Union[None, Dict[bytes, Any], List[List[Any]]]:
+    def xread(self, *args: bytes) -> None | dict[bytes, Any] | list[list[Any]]:
         ((count, timeout), left_args) = extract_args(args, ("+count", "+block"), error_on_unexpected=False)
         if len(left_args) < 3 or not casematch(left_args[0], b"STREAMS") or len(left_args) % 2 != 1:
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         left_args = left_args[1:]
         num_streams = int(len(left_args) / 2)
 
-        stream_start_id_list: List[Tuple[bytes, StreamRangeTest]] = []  # (name, start_id)
+        stream_start_id_list: list[tuple[bytes, StreamRangeTest]] = []  # (name, start_id)
         for i in range(num_streams):
             item = CommandItem(left_args[i], self._db, item=self._db.get(left_args[i]), default=None)
             start_id = self._parse_start_id(item, left_args[i + num_streams])
@@ -93,7 +95,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
     @command(name="XREADGROUP", fixed=(bytes, bytes, bytes), repeat=(bytes,))
     def xreadgroup(
         self, group_const: bytes, group_name: bytes, consumer_name: bytes, *args: bytes
-    ) -> Optional[Union[Dict[bytes, Any], List[List[Any]]]]:
+    ) -> dict[bytes, Any] | list[list[Any]] | None:
         if not casematch(b"GROUP", group_const):
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         (count, timeout, noack, min_idle_time), left_args = extract_args(
@@ -107,7 +109,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
         num_streams = int(len(left_args) / 2)
 
         # List of (group, stream_name, stream start-id)
-        group_params: List[Tuple[StreamGroup, bytes, bytes]] = []
+        group_params: list[tuple[StreamGroup, bytes, bytes]] = []
         for i in range(num_streams):
             item = CommandItem(left_args[i], self._db, item=self._db.get(left_args[i]), default=None)
             if item.value is None:
@@ -148,7 +150,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
         return group.ack(args)  # type: ignore
 
     @command(name="XPENDING", fixed=(Key(XStream), bytes), repeat=(bytes,))
-    def xpending(self, key: CommandItem, group_name: bytes, *args: bytes) -> Union[int, List[Any]]:
+    def xpending(self, key: CommandItem, group_name: bytes, *args: bytes) -> int | list[Any]:
         if key.value is None:
             return 0
         idle, start, end, count, consumer = None, None, None, None, None
@@ -223,34 +225,34 @@ class StreamsCommandsMixin(CommandsMixinBase):
         return group.del_consumer(consumer_name)
 
     @command(name="XINFO GROUPS", fixed=(Key(XStream),), repeat=())
-    def xinfo_groups(self, key: CommandItem) -> Dict[bytes, Any]:
+    def xinfo_groups(self, key: CommandItem) -> dict[bytes, Any]:
         if key.value is None:
             raise SimpleError(msgs.NO_KEY_MSG)
-        res: Dict[bytes, Any] = key.value.groups_info()
+        res: dict[bytes, Any] = key.value.groups_info()
         return res
 
     @command(name="XINFO STREAM", fixed=(Key(XStream),), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def xinfo_stream(self, key: CommandItem, *args: bytes) -> List[bytes]:
+    def xinfo_stream(self, key: CommandItem, *args: bytes) -> list[bytes]:
         (full,), _ = extract_args(args, ("full",))
         if key.value is None:
             raise SimpleError(msgs.NO_KEY_MSG)
-        res: List[bytes] = key.value.stream_info(full)
+        res: list[bytes] = key.value.stream_info(full)
         return res
 
     @command(name="XINFO CONSUMERS", fixed=(Key(XStream), bytes), repeat=())
-    def xinfo_consumers(self, key: CommandItem, group_name: bytes) -> List[Dict[str, Union[bytes, int]]]:
+    def xinfo_consumers(self, key: CommandItem, group_name: bytes) -> list[dict[str, bytes | int]]:
         if key.value is None:
             raise SimpleError(msgs.XGROUP_KEY_NOT_FOUND_MSG)
         group: StreamGroup = key.value.group_get(group_name)
         if not group:
             raise SimpleError(msgs.XGROUP_GROUP_NOT_FOUND_MSG.format(group_name.decode(), key))
-        res: List[Dict[str, Union[bytes, int]]] = group.consumers_info()
+        res: list[dict[str, bytes | int]] = group.consumers_info()
         return res
 
     @command(name="XCLAIM", fixed=(Key(XStream), bytes, bytes, Int, bytes), repeat=(bytes,))
     def xclaim(
         self, key: CommandItem, group_name: bytes, consumer_name: bytes, min_idle_ms: int, *args: bytes
-    ) -> Union[List[bytes], List[List[Union[bytes, List[bytes]]]]]:
+    ) -> list[bytes] | list[list[bytes | list[bytes]]]:
         stream = key.value
         if stream is None:
             raise SimpleError(msgs.XGROUP_KEY_NOT_FOUND_MSG)
@@ -258,7 +260,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
         if not group:
             raise SimpleError(msgs.XGROUP_GROUP_NOT_FOUND_MSG.format(group_name.decode(), key))
 
-        (idle, _time, retry, force, justid), msg_ids = extract_args(
+        (idle, _time, _retry, force, justid), msg_ids = extract_args(
             args,
             ("+idle", "+time", "+retrycount", "force", "justid"),
             error_on_unexpected=False,
@@ -276,7 +278,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
     @command(name="XAUTOCLAIM", fixed=(Key(XStream), bytes, bytes, Int, bytes), repeat=(bytes,))
     def xautoclaim(
         self, key: CommandItem, group_name: bytes, consumer_name: bytes, min_idle_ms: int, start: bytes, *args: bytes
-    ) -> List[Union[bytes, List[Union[bytes, List[Tuple[bytes, List[bytes]]]]]]]:
+    ) -> list[bytes | list[bytes | list[tuple[bytes, list[bytes]]]]]:
         (count, justid), _ = extract_args(args, ("+count", "justid"))
         count = count or 100
         stream = key.value
@@ -286,10 +288,10 @@ class StreamsCommandsMixin(CommandsMixinBase):
         if not group:
             raise SimpleError(msgs.XGROUP_GROUP_NOT_FOUND_MSG.format(group_name.decode(), key))
 
-        keys: List[StreamEntryKey] = group.read_pel_msgs(min_idle_ms, start, count)
+        keys: list[StreamEntryKey] = group.read_pel_msgs(min_idle_ms, start, count)
         msgs_claimed, msgs_removed = group.claim(min_idle_ms, keys, consumer_name, None, False)
 
-        res: List[Union[bytes, List[Union[bytes, List[Tuple[bytes, List[bytes]]]]]]] = [
+        res: list[bytes | list[bytes | list[tuple[bytes, list[bytes]]]]] = [
             max(msgs_claimed).encode() if len(msgs_claimed) > 0 else start,
             [msg.encode() for msg in msgs_claimed] if justid else [stream.format_record(msg) for msg in msgs_claimed],
         ]
@@ -298,7 +300,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
         return res
 
     @command(name="XDELEX", fixed=(Key(XStream),), repeat=(bytes,), server_types=("redis",))
-    def xdelex(self, key: CommandItem, *args: bytes) -> List[int]:
+    def xdelex(self, key: CommandItem, *args: bytes) -> list[int]:
         """XDELEX key [KEEPREF | DELREF | ACKED] IDS numids id [id ...]"""
         mode, ids = self._parse_xdelex_args(args, "XDELEX")
         if key.value is None:
@@ -308,7 +310,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
         return res
 
     @command(name="XACKDEL", fixed=(Key(XStream), bytes), repeat=(bytes,), server_types=("redis",))
-    def xackdel(self, key: CommandItem, group_name: bytes, *args: bytes) -> List[int]:
+    def xackdel(self, key: CommandItem, group_name: bytes, *args: bytes) -> list[int]:
         """XACKDEL key group [KEEPREF | DELREF | ACKED] IDS numids id [id ...]"""
         mode, ids = self._parse_xdelex_args(args, "XACKDEL")
         if key.value is None:
@@ -398,8 +400,8 @@ class StreamsCommandsMixin(CommandsMixinBase):
         _min: StreamRangeTest,
         _max: StreamRangeTest,
         reverse: bool,
-        count: Union[int, None],
-    ) -> List[bytes]:
+        count: int | None,
+    ) -> list[bytes]:
         if stream is None:
             return []
         if count is None:
@@ -410,16 +412,16 @@ class StreamsCommandsMixin(CommandsMixinBase):
     def _xreadgroup(
         self,
         consumer_name: bytes,
-        group_params: List[Tuple[StreamGroup, bytes, bytes]],
-        count: Optional[int],
+        group_params: list[tuple[StreamGroup, bytes, bytes]],
+        count: int | None,
         noack: bool,
-        min_idle_time: Optional[int],
+        min_idle_time: int | None,
         first_pass: bool,
-    ) -> Optional[Dict[bytes, Any]]:
-        res: Dict[bytes, Any] = {}
+    ) -> dict[bytes, Any] | None:
+        res: dict[bytes, Any] = {}
         claimed_any = False
         for group, stream_name, start_id in group_params:
-            claimed: List[Any] = []
+            claimed: list[Any] = []
             # CLAIM only applies when reading new entries, not the consumer history
             claim_active = False
             if min_idle_time is not None and start_id == b">":
@@ -427,7 +429,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
                 claimed = group.claim_for_read(min_idle_time, consumer_name, count)
                 claimed_any = claimed_any or len(claimed) > 0
             remaining_count = count - len(claimed) if count is not None else None
-            stream_results: List[Any] = group.group_read(consumer_name, start_id, remaining_count, noack)
+            stream_results: list[Any] = group.group_read(consumer_name, start_id, remaining_count, noack)
             if first_pass and (count is None) and not claimed_any:
                 return None
             if claim_active:
@@ -439,10 +441,10 @@ class StreamsCommandsMixin(CommandsMixinBase):
         return res
 
     def _xread(
-        self, stream_start_id_list: List[Tuple[bytes, StreamRangeTest]], count: int, blocking: bool, first_pass: bool
-    ) -> Union[None, Dict[bytes, Any], List[List[Union[bytes, List[Tuple[bytes, List[bytes]]]]]]]:
+        self, stream_start_id_list: list[tuple[bytes, StreamRangeTest]], count: int, blocking: bool, first_pass: bool
+    ) -> None | dict[bytes, Any] | list[list[bytes | list[tuple[bytes, list[bytes]]]]]:
         max_inf = StreamRangeTest.decode(b"+")
-        res: Dict[bytes, Any] = {}
+        res: dict[bytes, Any] = {}
         for stream_name, start_id in stream_start_id_list:
             item = CommandItem(stream_name, self._db, item=self._db.get(stream_name), default=None)
             stream_results = self._xrange(item.value, start_id, max_inf, False, count)

--- a/fakeredis/commands_mixins/string_mixin.py
+++ b/fakeredis/commands_mixins/string_mixin.py
@@ -1,34 +1,36 @@
+from __future__ import annotations
+
 import math
 import sys
-from abc import abstractmethod, ABC
-from typing import Tuple, Callable, List, Any, Optional, Dict, Union
+from abc import ABC, abstractmethod
+from typing import Any, Callable
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
 from fakeredis._commands import (
-    command,
-    Key,
-    Int,
-    Float,
     MAX_STRING_SIZE,
+    CommandItem,
+    Float,
+    Int,
+    Key,
+    command,
     delete_keys,
     fix_range_string,
-    CommandItem,
 )
-from fakeredis._helpers import OK, SimpleError, casematch, SimpleString
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis._typing import VersionType
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 
 
-def _lcs(s1: bytes, s2: bytes) -> Tuple[int, bytes, List[Any]]:
+def _lcs(s1: bytes, s2: bytes) -> tuple[int, bytes, list[Any]]:
     l1 = len(s1)
     l2 = len(s2)
 
     # Opt array to store the optimal solution value till ith and jth position for 2 strings
-    opt: List[List[int]] = [[0] * (l2 + 1) for _ in range(0, l1 + 1)]
+    opt: list[list[int]] = [[0] * (l2 + 1) for _ in range(l1 + 1)]
 
     # Pi array to store the direction when calculating the actual sequence
-    pi: List[List[int]] = [[0] * (l2 + 1) for _ in range(0, l1 + 1)]
+    pi: list[list[int]] = [[0] * (l2 + 1) for _ in range(l1 + 1)]
 
     # Algorithm to calculate the length of the longest common subsequence
     for r in range(1, l1 + 1):
@@ -140,7 +142,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
     def incr(self, key: CommandItem) -> int:
         return self._incrby(key, 1)
 
-    def _increx_bound(self, raw: Optional[bytes], name: str, float_mode: bool, default: float) -> Union[int, float]:
+    def _increx_bound(self, raw: bytes | None, name: str, float_mode: bool, default: float) -> int | float:
         if raw is None:
             return default
         if float_mode:
@@ -148,7 +150,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
         return Int.decode(raw, decode_error=msgs.INCREX_BOUND_NOT_INTEGER_MSG.format(name))
 
     @command(name="INCREX", fixed=(Key(bytes),), repeat=(bytes,), server_types=("redis",))
-    def increx(self, key: CommandItem, *args: bytes) -> List[Any]:
+    def increx(self, key: CommandItem, *args: bytes) -> list[Any]:
         if self.version < (8, 8):
             raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format("INCREX"))
         (byfloat, byint, saturate, lbound, ubound, ex, px, exat, pxat, persist, enx), _ = extract_args(
@@ -166,7 +168,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
             raise SimpleError(msgs.INCREX_ENX_REQUIRES_EXPIRATION_MSG)
         if (ex is not None and ex <= 0) or (px is not None and px <= 0):
             raise SimpleError(msgs.INVALID_EXPIRE_MSG_REDIS_8.format("increx"))
-        expire_time: Optional[float] = None
+        expire_time: float | None = None
         if exat is not None:
             expire_time = exat
         elif pxat is not None:
@@ -185,8 +187,8 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
         if lower > upper:
             raise SimpleError(msgs.INCREX_LBOUND_GT_UBOUND_MSG)
 
-        current: Union[int, float]
-        amount: Union[int, float]
+        current: int | float
+        amount: int | float
         if float_mode:
             current = Float.decode(key.get(b"0"))
             amount = Float.decode(byfloat)
@@ -231,7 +233,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
         return encoded
 
     @command(fixed=(Key(),), repeat=(Key(),))
-    def mget(self, *keys: CommandItem) -> List[Optional[bytes]]:
+    def mget(self, *keys: CommandItem) -> list[bytes | None]:
         return [key.value if isinstance(key.value, bytes) else None for key in keys]
 
     @command((Key(), bytes), (Key(), bytes))
@@ -371,7 +373,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
         return key.get(None)
 
     @command(fixed=(Key(bytes), Key(bytes)), repeat=(bytes,))
-    def lcs(self, k1: CommandItem, k2: CommandItem, *args: bytes) -> Union[bytes, int, Dict[bytes, Any]]:
+    def lcs(self, k1: CommandItem, k2: CommandItem, *args: bytes) -> bytes | int | dict[bytes, Any]:
         s1 = k1.value or b""
         s2 = k2.value or b""
 
@@ -386,7 +388,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
         if arg_len:
             return lcs_len
         arg_minmatchlen = arg_minmatchlen if arg_minmatchlen else 0
-        results: List[Any] = list(filter(lambda x: x[2] >= arg_minmatchlen, matches))
+        results: list[Any] = list(filter(lambda x: x[2] >= arg_minmatchlen, matches))
         if not arg_withmatchlen:
             results = [[x[0], x[1]] for x in results]
         return {b"matches": results, b"len": lcs_len}

--- a/fakeredis/commands_mixins/transactions_mixin.py
+++ b/fakeredis/commands_mixins/transactions_mixin.py
@@ -1,7 +1,9 @@
-from typing import Callable, Set, Any, List, Optional
+from __future__ import annotations
+
+from typing import Any, Callable
 
 from fakeredis import _msgs as msgs
-from fakeredis._commands import command, Key, CommandItem
+from fakeredis._commands import CommandItem, Key, command
 from fakeredis._helpers import OK, SimpleError, SimpleString
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 
@@ -10,10 +12,10 @@ class TransactionsCommandsMixin(CommandsMixinBase):
     _run_command: Callable  # type: ignore
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore
-        super(TransactionsCommandsMixin, self).__init__(*args, **kwargs)
-        self._watches: Set[Any] = set()
+        super().__init__(*args, **kwargs)
+        self._watches: set[Any] = set()
         # When in a MULTI, set to a list of function calls
-        self._transaction: Optional[List[Any]] = None
+        self._transaction: list[Any] | None = None
         self._transaction_failed = False
         # Set when executing the commands from EXEC
         self._in_transaction = False

--- a/fakeredis/geo/__init__.py
+++ b/fakeredis/geo/__init__.py
@@ -1,8 +1,8 @@
-from .geohash import geo_encode, geo_decode
+from .geohash import geo_decode, geo_encode
 from .haversine import distance
 
 __all__ = [
-    "geo_encode",
-    "geo_decode",
     "distance",
+    "geo_decode",
+    "geo_encode",
 ]

--- a/fakeredis/geo/geohash.py
+++ b/fakeredis/geo/geohash.py
@@ -2,6 +2,8 @@
 #  alphabet described in IETF's RFC 4648
 #  (http://tools.ietf.org/html/rfc4648)
 
+from __future__ import annotations
+
 base32 = "0123456789bcdefghjkmnpqrstuvwxyz"
 decodemap = {base32[i]: i for i in range(len(base32))}
 

--- a/fakeredis/geo/geohash.py
+++ b/fakeredis/geo/geohash.py
@@ -1,13 +1,12 @@
 #  Note: the alphabet in geohash differs from the common base32
 #  alphabet described in IETF's RFC 4648
 #  (http://tools.ietf.org/html/rfc4648)
-from typing import Tuple
 
 base32 = "0123456789bcdefghjkmnpqrstuvwxyz"
 decodemap = {base32[i]: i for i in range(len(base32))}
 
 
-def geo_decode(geohash: str) -> Tuple[float, float, float, float]:
+def geo_decode(geohash: str) -> tuple[float, float, float, float]:
     """
     Decode the geohash to its exact values, including the error margins of the result.  Returns four float values:
     latitude, longitude, the plus/minus error for latitude (as a positive number) and the plus/minus error for longitude
@@ -59,7 +58,7 @@ def geo_encode(latitude: float, longitude: float, precision: int = 12) -> str:
     bit, ch = 0, 0
     is_longitude = True
 
-    def next_interval(curr: float, interval: Tuple[float, float], ch: int) -> Tuple[Tuple[float, float], int]:
+    def next_interval(curr: float, interval: tuple[float, float], ch: int) -> tuple[tuple[float, float], int]:
         mid = (interval[0] + interval[1]) / 2
         if curr > mid:
             ch |= bits[bit]

--- a/fakeredis/geo/haversine.py
+++ b/fakeredis/geo/haversine.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 

--- a/fakeredis/geo/haversine.py
+++ b/fakeredis/geo/haversine.py
@@ -1,8 +1,7 @@
 import math
-from typing import Tuple
 
 
-def distance(origin: Tuple[float, float], destination: Tuple[float, float]) -> float:
+def distance(origin: tuple[float, float], destination: tuple[float, float]) -> float:
     """Calculate the Haversine distance in meters."""
     radius = 6372797.560856  # Earth's quatratic mean radius for WGS-84
 

--- a/fakeredis/model/__init__.py
+++ b/fakeredis/model/__init__.py
@@ -2,57 +2,58 @@ from ._acl import AccessControlList
 from ._array import Array
 from ._base_type import BaseModel
 from ._client_info import ClientInfo
-
 from ._command_info import (
     get_all_commands_info,
-    get_command_info,
     get_categories,
+    get_command_info,
     get_commands_by_category,
 )
 from ._expiring_members_set import ExpiringMembersSet
 from ._hash import Hash
-from ._stream import XStream, StreamEntryKey, StreamGroup, StreamRangeTest
+from ._stream import StreamEntryKey, StreamGroup, StreamRangeTest, XStream
 from ._tdigest import TDigest
-from ._timeseries_model import TimeSeries, TimeSeriesRule, AGGREGATORS
+from ._timeseries_model import AGGREGATORS, TimeSeries, TimeSeriesRule
 from ._topk import HeavyKeeper
 from ._zset import ZSet
 
 __all__ = [
+    "AGGREGATORS",
+    "AccessControlList",
     "Array",
     "BaseModel",
-    "XStream",
-    "StreamRangeTest",
-    "StreamGroup",
+    "ClientInfo",
+    "ExpiringMembersSet",
+    "Hash",
+    "HeavyKeeper",
     "StreamEntryKey",
-    "ZSet",
+    "StreamGroup",
+    "StreamRangeTest",
+    "TDigest",
     "TimeSeries",
     "TimeSeriesRule",
-    "AGGREGATORS",
-    "HeavyKeeper",
-    "Hash",
-    "ExpiringMembersSet",
+    "XStream",
+    "ZSet",
     "get_all_commands_info",
-    "get_command_info",
     "get_categories",
+    "get_command_info",
     "get_commands_by_category",
-    "AccessControlList",
-    "ClientInfo",
-    "TDigest",
 ]
 
 try:
     import numpy as np  # noqa: F401
-    from ._vectorset import VectorSet, Vector  # noqa: F401
 
-    __all__.extend(["VectorSet", "Vector"])
+    from ._vectorset import Vector, VectorSet  # noqa: F401
+
+    __all__.extend(["Vector", "VectorSet"])
 except ImportError:
     pass
 
 try:
     import probables  # noqa: F401
-    from ._filters import ScalableCuckooFilter, ScalableBloomFilter  # noqa: F401
-    from ._cms import CountMinSketch  # noqa: F401
 
-    __all__.extend(["CountMinSketch", "ScalableCuckooFilter", "ScalableBloomFilter"])
+    from ._cms import CountMinSketch  # noqa: F401
+    from ._filters import ScalableBloomFilter, ScalableCuckooFilter  # noqa: F401
+
+    __all__.extend(["CountMinSketch", "ScalableBloomFilter", "ScalableCuckooFilter"])
 except ImportError:
     pass

--- a/fakeredis/model/_acl.py
+++ b/fakeredis/model/_acl.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import fnmatch
 import hashlib
-from typing import Dict, Set, List, Union, Optional, Any
+from typing import Any
 
 from fakeredis import _msgs as msgs
-from ._command_info import get_commands_by_category, get_command_info
+
 from .._helpers import SimpleError, current_time
+from ._command_info import get_command_info, get_commands_by_category
 
 
 class Selector:
@@ -14,11 +17,11 @@ class Selector:
         self.keys: bytes = keys
         self.channels: bytes = channels
 
-    def as_array(self) -> List[bytes]:
+    def as_array(self) -> list[bytes]:
         return [b"+" if self.allowed else b"-", self.command, b"keys", self.keys, b"channels", self.channels]
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> "Selector":
+    def from_bytes(cls, data: bytes) -> Selector:
         keys = b""
         channels = b""
         command = b""
@@ -46,13 +49,13 @@ class Selector:
 
 class UserAccessControlList:
     def __init__(self, enabled: bool = True, nopass: bool = False):
-        self._passwords: Set[bytes] = set()
+        self._passwords: set[bytes] = set()
         self.enabled: bool = enabled
         self._nopass: bool = nopass
-        self._key_patterns: Set[bytes] = set()
-        self._channel_patterns: Set[bytes] = set()
-        self._commands: Dict[bytes, bool] = {b"@all": False}
-        self._selectors: Dict[bytes, Selector] = {}
+        self._key_patterns: set[bytes] = set()
+        self._channel_patterns: set[bytes] = set()
+        self._commands: dict[bytes, bool] = {b"@all": False}
+        self._selectors: dict[bytes, Selector] = {}
 
     def reset(self) -> None:
         self.enabled = False
@@ -64,7 +67,7 @@ class UserAccessControlList:
         self._selectors.clear()
 
     @staticmethod
-    def _get_command_info(fields: List[bytes]) -> Optional[List[Any]]:
+    def _get_command_info(fields: list[bytes]) -> list[Any] | None:
         command = fields[0].lower()
         command_info = get_command_info(command)
         if not command_info and len(fields) > 1:
@@ -72,7 +75,7 @@ class UserAccessControlList:
             command_info = get_command_info(command)
         return command_info
 
-    def command_allowed(self, command_info: Optional[List[Any]], fields: List[bytes]) -> bool:
+    def command_allowed(self, command_info: list[Any] | None, fields: list[bytes]) -> bool:
         res = fields[0].lower() == b"auth" or self._commands.get(fields[0].lower(), False)
         res = res or self._commands.get(b"@all", False)
         if not command_info:
@@ -81,7 +84,7 @@ class UserAccessControlList:
             res = res or self._commands.get(category, False)
         return res
 
-    def _get_keys(self, command_info: Optional[List[Any]], fields: List[bytes]) -> List[bytes]:
+    def _get_keys(self, command_info: list[Any] | None, fields: list[bytes]) -> list[bytes]:
         if not command_info:
             return []
         first_key, last_key, step = command_info[3:6]
@@ -91,20 +94,20 @@ class UserAccessControlList:
         step = step + 1
         return fields[first_key : last_key + 1 : step]
 
-    def keys_not_allowed(self, command_info: Optional[List[Any]], fields: List[bytes]) -> List[bytes]:
+    def keys_not_allowed(self, command_info: list[Any] | None, fields: list[bytes]) -> list[bytes]:
         if len(self._key_patterns) == 0:
             return []
         keys = self._get_keys(command_info, fields)
-        res: Set[bytes] = set()
+        res: set[bytes] = set()
         for pat in self._key_patterns:
             res = res.union(fnmatch.filter(keys, pat))
         return list(set(keys) - res)
 
-    def channels_not_allowed(self, command_info: Optional[List[Any]], fields: List[bytes]) -> List[bytes]:
+    def channels_not_allowed(self, command_info: list[Any] | None, fields: list[bytes]) -> list[bytes]:
         if len(self._channel_patterns) == 0:
             return []
         channels = fields[1:2]
-        res: Set[bytes] = set()
+        res: set[bytes] = set()
         for pat in self._channel_patterns:
             res = res.union(fnmatch.filter(channels, pat))
         return list(set(channels) - res)
@@ -113,7 +116,7 @@ class UserAccessControlList:
         self._nopass = True
         self._passwords.clear()
 
-    def check_password(self, password: Optional[bytes]) -> bool:
+    def check_password(self, password: bytes | None) -> bool:
         password_provided: bool = password is not None and password != b""
         if self._nopass:
             return not password_provided
@@ -165,10 +168,10 @@ class UserAccessControlList:
         parsed_selector = Selector.from_bytes(selector)
         self._selectors[parsed_selector.command] = parsed_selector
 
-    def _get_selectors(self) -> List[Dict[str, bytes]]:
-        results: List[Dict[str, bytes]] = []
+    def _get_selectors(self) -> list[dict[str, bytes]]:
+        results: list[dict[str, bytes]] = []
         for command, selector in self._selectors.items():
-            s: Dict[str, bytes] = {
+            s: dict[str, bytes] = {
                 "commands": b"-@all " + (b"+" if selector.allowed else b"-") + command,
                 "keys": selector.keys,
                 "channels": selector.channels,
@@ -176,21 +179,21 @@ class UserAccessControlList:
             results.append(s)
         return results
 
-    def _get_commands(self) -> List[bytes]:
+    def _get_commands(self) -> list[bytes]:
         res = []
         for command, enabled in self._commands.items():
             inc = b"+" if enabled else b"-"
             res.append(inc + command)
         return res
 
-    def _get_key_patterns(self) -> List[bytes]:
+    def _get_key_patterns(self) -> list[bytes]:
         return [b"~" + key_pattern for key_pattern in self._key_patterns]
 
-    def _get_channel_patterns(self) -> List[bytes]:
+    def _get_channel_patterns(self) -> list[bytes]:
         return [b"&" + channel_pattern for channel_pattern in self._channel_patterns]
 
-    def _get_flags(self) -> List[bytes]:
-        flags: List[bytes] = []
+    def _get_flags(self) -> list[bytes]:
+        flags: list[bytes] = []
         flags.append(b"on" if self.enabled else b"off")
         if self._nopass:
             flags.append(b"nopass")
@@ -200,8 +203,8 @@ class UserAccessControlList:
             flags.append(b"allchannels")
         return flags
 
-    def as_array(self) -> List[Union[bytes, List[bytes], List[Dict[str, bytes]]]]:
-        results: List[Union[bytes, List[bytes], List[Dict[str, bytes]]]] = []
+    def as_array(self) -> list[bytes | list[bytes] | list[dict[str, bytes]]]:
+        results: list[bytes | list[bytes] | list[dict[str, bytes]]] = []
         results.extend(
             [
                 b"flags",
@@ -220,8 +223,8 @@ class UserAccessControlList:
         )
         return results
 
-    def _get_selectors_for_rule(self) -> List[bytes]:
-        results: List[bytes] = []
+    def _get_selectors_for_rule(self) -> list[bytes]:
+        results: list[bytes] = []
         for command, selector in self._selectors.items():
             s = b"-@all " + (b"+" if selector.allowed else b"-") + command
             channels = b"resetchannels" + ((b" " + selector.channels) if selector.channels != b"" else b"")
@@ -233,7 +236,7 @@ class UserAccessControlList:
         channels = self._get_channel_patterns()
         if channels != [b"&*"]:
             channels = [b"resetchannels"] + channels
-        rule_parts: List[bytes] = (
+        rule_parts: list[bytes] = (
             self._get_flags()
             + [b"#" + password for password in self._passwords]
             + self._get_commands()
@@ -267,9 +270,9 @@ class AclLogRecord:
         self.client_info: bytes = client_info
         self.entry_id: int = entry_id
 
-    def as_dict(self) -> Dict[str, bytes]:
+    def as_dict(self) -> dict[str, bytes]:
         age_seconds = (current_time() - self.created_ts) / 1000
-        res: Dict[str, bytes] = {
+        res: dict[str, bytes] = {
             "count": str(self.count).encode(),
             "reason": self.reason,
             "context": self.context,
@@ -290,17 +293,17 @@ class AccessControlList:
         default_user_acl.add_key_pattern(b"*")
         default_user_acl.add_channel_pattern(b"*")
         default_user_acl.add_command_or_category(b"+@all")
-        self._user_acl: Dict[bytes, UserAccessControlList] = {b"default": default_user_acl}
-        self._log: List[AclLogRecord] = []
+        self._user_acl: dict[bytes, UserAccessControlList] = {b"default": default_user_acl}
+        self._log: list[AclLogRecord] = []
 
-    def get_users(self) -> List[bytes]:
+    def get_users(self) -> list[bytes]:
         return list(self._user_acl.keys())
 
     def get_user_acl(self, username: bytes) -> UserAccessControlList:
         return self._user_acl.setdefault(username, UserAccessControlList())
 
-    def as_rules(self) -> List[bytes]:
-        res: List[bytes] = []
+    def as_rules(self) -> list[bytes]:
+        res: list[bytes] = []
         for username, user_acl in self._user_acl.items():
             rule_str = b"user " + username + b" " + user_acl.as_rule()
             res.append(rule_str)
@@ -312,7 +315,7 @@ class AccessControlList:
     def reset_log(self) -> None:
         self._log.clear()
 
-    def log(self, count: int) -> List[Dict[str, bytes]]:
+    def log(self, count: int) -> list[dict[str, bytes]]:
         if count > len(self._log) or count < 0:
             count = 0
         res = [x.as_dict() for x in self._log[-count:]]
@@ -343,7 +346,7 @@ class AccessControlList:
         )
         self._log.append(entry)
 
-    def validate_command(self, username: bytes, client_info: bytes, fields: List[bytes]) -> None:
+    def validate_command(self, username: bytes, client_info: bytes, fields: list[bytes]) -> None:
         if username not in self._user_acl:
             return
         if fields and fields[0].lower() == b"auth":

--- a/fakeredis/model/_array.py
+++ b/fakeredis/model/_array.py
@@ -1,6 +1,6 @@
-import re
-from typing import Dict, List, Optional, Tuple
+from __future__ import annotations
 
+import re
 
 from fakeredis.model._base_type import BaseModel
 
@@ -9,10 +9,10 @@ class Array(BaseModel):
     _model_type = b"array"
 
     def __init__(self) -> None:
-        self._data: Dict[int, bytes] = {}
+        self._data: dict[int, bytes] = {}
         self._cursor: int = 0
         # ordered dict used as ordered set: index -> None, keyed by last-insert time
-        self._insertion_order: Dict[int, None] = {}
+        self._insertion_order: dict[int, None] = {}
 
     def __len__(self) -> int:
         return len(self._data)
@@ -27,7 +27,7 @@ class Array(BaseModel):
         """ARCOUNT: number of non-empty (set) elements."""
         return len(self._data)
 
-    def get(self, index: int) -> Optional[bytes]:
+    def get(self, index: int) -> bytes | None:
         return self._data.get(index)
 
     def set(self, index: int, value: bytes) -> bool:
@@ -54,13 +54,13 @@ class Array(BaseModel):
         self._insertion_order.pop(index, None)
         self._insertion_order[index] = None
 
-    def lastitems(self, count: int) -> List[bytes]:
+    def lastitems(self, count: int) -> list[bytes]:
         """Return the last `count` inserted values (oldest-first)."""
         existing = [i for i in self._insertion_order if i in self._data]
         recent = existing[-count:] if count < len(existing) else existing
         return [self._data[i] for i in recent]
 
-    def scan_range(self, start: int, end: int, limit: Optional[int] = None) -> List[Tuple[int, bytes]]:
+    def scan_range(self, start: int, end: int, limit: int | None = None) -> list[tuple[int, bytes]]:
         """Return existing index-value pairs in [start, end] (inclusive).
 
         If start > end the range is traversed in descending order.
@@ -78,18 +78,18 @@ class Array(BaseModel):
         self,
         start: int,
         end: int,
-        predicates: List[Tuple[str, str]],
+        predicates: list[tuple[str, str]],
         use_and: bool,
-        limit: Optional[int],
+        limit: int | None,
         nocase: bool,
-    ) -> List[Tuple[int, bytes]]:
+    ) -> list[tuple[int, bytes]]:
         """Return (index, value) pairs in range matching the textual predicates."""
         if start <= end:
             indices = sorted(k for k in self._data if start <= k <= end)
         else:
             indices = sorted((k for k in self._data if end <= k <= start), reverse=True)
 
-        results: List[Tuple[int, bytes]] = []
+        results: list[tuple[int, bytes]] = []
         for idx in indices:
             val = self._data[idx]
             text = val.decode(errors="replace")
@@ -118,7 +118,7 @@ class Array(BaseModel):
                     break
         return results
 
-    def op_range(self, start: int, end: int, operation: str, operand: Optional[bytes] = None):
+    def op_range(self, start: int, end: int, operation: str, operand: bytes | None = None):
         """Perform an aggregate operation on elements in [start, end]."""
         if start > end:
             start, end = end, start

--- a/fakeredis/model/_client_info.py
+++ b/fakeredis/model/_client_info.py
@@ -1,8 +1,10 @@
 import time
-from typing import Any
+from typing import Any, Dict
 
 
-class ClientInfo(dict[str, Any]):
+# Subclassing a parameterized generic is evaluated at runtime, so use typing.Dict
+# (not the PEP 585 builtin) to keep this importable on Python 3.8.
+class ClientInfo(Dict[str, Any]):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__()
         kwargs.setdefault("-created", int(time.time()))

--- a/fakeredis/model/_client_info.py
+++ b/fakeredis/model/_client_info.py
@@ -1,8 +1,8 @@
 import time
-from typing import Any, Dict
+from typing import Any
 
 
-class ClientInfo(Dict[str, Any]):
+class ClientInfo(dict[str, Any]):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__()
         kwargs.setdefault("-created", int(time.time()))

--- a/fakeredis/model/_cms.py
+++ b/fakeredis/model/_cms.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 import probables
 
@@ -10,9 +10,9 @@ class CountMinSketch(probables.CountMinSketch, BaseModel):
 
     def __init__(
         self,
-        width: Optional[int] = None,
-        depth: Optional[int] = None,
-        probability: Optional[float] = None,
-        error_rate: Optional[float] = None,
+        width: int | None = None,
+        depth: int | None = None,
+        probability: float | None = None,
+        error_rate: float | None = None,
     ):
         super().__init__(width=width, depth=depth, error_rate=error_rate, confidence=probability)

--- a/fakeredis/model/_command_info.py
+++ b/fakeredis/model/_command_info.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Optional, Dict, List, Any, AnyStr
+from typing import Any, AnyStr
+
 from fakeredis._helpers import asbytes
 
-_COMMAND_INFO: Optional[Dict[bytes, List[Any]]] = None
+_COMMAND_INFO: dict[bytes, list[Any]] | None = None
 
 
 def _encode_obj(obj: Any) -> Any:
@@ -23,19 +26,19 @@ def _load_command_info() -> None:
             _COMMAND_INFO = _encode_obj(json.load(f))
 
 
-def get_all_commands_info() -> Dict[bytes, List[Any]]:
+def get_all_commands_info() -> dict[bytes, list[Any]]:
     _load_command_info()
     return _COMMAND_INFO  # type: ignore[return-value]
 
 
-def get_command_info(cmd: bytes) -> Optional[List[Any]]:
+def get_command_info(cmd: bytes) -> list[Any] | None:
     _load_command_info()
     if _COMMAND_INFO is None or cmd not in _COMMAND_INFO:
         return None
     return _COMMAND_INFO.get(cmd, None)
 
 
-def get_categories() -> List[bytes]:
+def get_categories() -> list[bytes]:
     _load_command_info()
     if _COMMAND_INFO is None:
         return []
@@ -46,7 +49,7 @@ def get_categories() -> List[bytes]:
     return list(categories)
 
 
-def get_commands_by_category(_category: AnyStr) -> List[bytes]:
+def get_commands_by_category(_category: AnyStr) -> list[bytes]:
     _load_command_info()
     if _COMMAND_INFO is None:
         return []

--- a/fakeredis/model/_expiring_members_set.py
+++ b/fakeredis/model/_expiring_members_set.py
@@ -1,8 +1,12 @@
-from typing import Iterable, Iterator, Optional, Any, Dict, Union, Set
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
 
 from fakeredis import _msgs as msgs
 from fakeredis._helpers import current_time
 from fakeredis._typing import Self
+
 from ._base_type import BaseModel
 
 
@@ -10,9 +14,9 @@ class ExpiringMembersSet(BaseModel):
     DECODE_ERROR = msgs.INVALID_HASH_MSG
     _model_type = b"set"
 
-    def __init__(self, values: Optional[Dict[bytes, Optional[int]]] = None, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, values: dict[bytes, int | None] | None = None, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._values: Dict[bytes, Optional[int]] = values or {}
+        self._values: dict[bytes, int | None] = values or {}
 
     def _expire_members(self) -> None:
         now = current_time()
@@ -31,7 +35,7 @@ class ExpiringMembersSet(BaseModel):
     def clear_key_expireat(self, key: bytes) -> bool:
         return self._values.pop(key, None) is not None
 
-    def get_key_expireat(self, key: bytes) -> Optional[int]:
+    def get_key_expireat(self, key: bytes) -> int | None:
         self._expire_members()
         return self._values.get(key, None)
 
@@ -51,26 +55,26 @@ class ExpiringMembersSet(BaseModel):
         now = current_time()
         return iter({k for k in self._values if (self._values[k] or (now + 1)) >= now})
 
-    def __get__(self, instance: object, owner: None = None) -> Set[bytes]:
+    def __get__(self, instance: object, owner: None = None) -> set[bytes]:
         self._expire_members()
         return set(self._values.keys())
 
-    def __sub__(self, other: Self) -> "ExpiringMembersSet":
+    def __sub__(self, other: Self) -> ExpiringMembersSet:
         self._expire_members()
         other._expire_members()
         return ExpiringMembersSet({k: v for k, v in self._values.items() if k not in other._values})
 
-    def __and__(self, other: Self) -> "ExpiringMembersSet":
+    def __and__(self, other: Self) -> ExpiringMembersSet:
         self._expire_members()
         other._expire_members()
         return ExpiringMembersSet({k: v for k, v in self._values.items() if k in other._values})
 
-    def __or__(self, other: Self) -> "ExpiringMembersSet":
+    def __or__(self, other: Self) -> ExpiringMembersSet:
         self._expire_members()
         other._expire_members()
         return ExpiringMembersSet(dict(self._values.items())).update(other)
 
-    def update(self, other: Union[Self, Iterable[bytes]]) -> Self:
+    def update(self, other: Self | Iterable[bytes]) -> Self:
         self._expire_members()
         if isinstance(other, ExpiringMembersSet):
             self._values.update(other._values)
@@ -88,5 +92,5 @@ class ExpiringMembersSet(BaseModel):
     def add(self, key: bytes) -> None:
         self._values[key] = None
 
-    def copy(self) -> "ExpiringMembersSet":
+    def copy(self) -> ExpiringMembersSet:
         return ExpiringMembersSet(self._values.copy())

--- a/fakeredis/model/_filters.py
+++ b/fakeredis/model/_filters.py
@@ -1,10 +1,11 @@
-from typing import Any, ByteString
+from typing import Any
 
 from probables import CountingCuckooFilter, CuckooFilterFullError, ExpandingBloomFilter
 
 from fakeredis import _msgs as msgs
-from ._base_type import BaseModel
+
 from .._helpers import SimpleError
+from ._base_type import BaseModel
 
 
 class ScalableBloomFilter(ExpandingBloomFilter, BaseModel):
@@ -20,7 +21,7 @@ class ScalableBloomFilter(ExpandingBloomFilter, BaseModel):
             return True
         if self.scale == self.NO_GROWTH and self.elements_added >= self.estimated_elements:
             raise SimpleError(msgs.FILTER_FULL_MSG)
-        super(ScalableBloomFilter, self).add(key)
+        super().add(key)
         return False
 
     @classmethod
@@ -59,7 +60,7 @@ class ScalableCuckooFilter(CountingCuckooFilter, BaseModel):
         return False
 
     @classmethod
-    def frombytes(cls, b: ByteString, **kwargs: Any) -> "ScalableCuckooFilter":  # type: ignore[override]
+    def frombytes(cls, b: bytes, **kwargs: Any) -> "ScalableCuckooFilter":  # type: ignore[override]
         base = CountingCuckooFilter.frombytes(b, **kwargs)
         obj = cls.__new__(cls)
         for c in CountingCuckooFilter.__mro__:

--- a/fakeredis/model/_hash.py
+++ b/fakeredis/model/_hash.py
@@ -1,7 +1,11 @@
-from typing import Iterable, Iterator, List, Tuple, Optional, Any, Dict, AnyStr
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any, AnyStr
 
 from fakeredis import _msgs as msgs
-from fakeredis._helpers import current_time, asbytes
+from fakeredis._helpers import asbytes, current_time
+
 from ._base_type import BaseModel
 
 
@@ -11,10 +15,10 @@ class Hash(BaseModel):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._expirations: Dict[bytes, int] = {}
-        self._values: Dict[bytes, bytes] = {}
+        self._expirations: dict[bytes, int] = {}
+        self._values: dict[bytes, bytes] = {}
         # Fields that expired lazily, pending an `hexpired` subkey notification.
-        self._expired_fields: List[bytes] = []
+        self._expired_fields: list[bytes] = []
 
     def _expire_keys(self) -> None:
         now = current_time()
@@ -24,7 +28,7 @@ class Hash(BaseModel):
             del self._expirations[k]
         self._expired_fields.extend(expired)
 
-    def take_expired_fields(self) -> List[bytes]:
+    def take_expired_fields(self) -> list[bytes]:
         """Return fields that expired since the last call, clearing the buffer."""
         res, self._expired_fields = self._expired_fields, []
         return res
@@ -42,7 +46,7 @@ class Hash(BaseModel):
     def clear_key_expireat(self, key: AnyStr) -> bool:
         return self._expirations.pop(asbytes(key), None) is not None
 
-    def get_key_expireat(self, key: AnyStr) -> Optional[int]:
+    def get_key_expireat(self, key: AnyStr) -> int | None:
         self._expire_keys()
         return self._expirations.get(asbytes(key), None)
 
@@ -78,16 +82,16 @@ class Hash(BaseModel):
 
     def keys(self) -> Iterable[bytes]:
         self._expire_keys()
-        return [asbytes(k) for k in self._values.keys()]
+        return [asbytes(k) for k in self._values]
 
     def values(self) -> Iterable[Any]:
         return [v for k, v in self.items()]
 
-    def items(self) -> Iterable[Tuple[bytes, Any]]:
+    def items(self) -> Iterable[tuple[bytes, Any]]:
         self._expire_keys()
         return [(asbytes(k), asbytes(v)) for k, v in self._values.items()]
 
-    def update(self, values: Dict[bytes, Any], clear_expiration: bool) -> None:
+    def update(self, values: dict[bytes, Any], clear_expiration: bool) -> None:
         self._expire_keys()
         if clear_expiration:
             for k, v in values.items():
@@ -95,7 +99,7 @@ class Hash(BaseModel):
         for k, v in values.items():
             self._values[asbytes(k)] = v
 
-    def getall(self) -> Dict[bytes, bytes]:
+    def getall(self) -> dict[bytes, bytes]:
         self._expire_keys()
         res = self._values.copy()
         return {asbytes(k): asbytes(v) for k, v in res.items()}

--- a/fakeredis/model/_stream.py
+++ b/fakeredis/model/_stream.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import bisect
 import itertools
 import sys
 import time
 from collections import Counter
+from collections.abc import Generator, Sequence
 from dataclasses import dataclass
-from typing import List, Union, Tuple, Optional, NamedTuple, Dict, Any, Sequence, Generator, AnyStr
+from typing import Any, AnyStr, NamedTuple
 
-from fakeredis._commands import BeforeAny, AfterAny
-from fakeredis._helpers import current_time, SimpleError
+from fakeredis._commands import AfterAny, BeforeAny
+from fakeredis._helpers import SimpleError, current_time
+
 from ._base_type import BaseModel
 
 
@@ -19,10 +23,10 @@ class StreamEntryKey(NamedTuple):
         return f"{self.ts}-{self.seq}".encode()
 
     @staticmethod
-    def parse_str(entry_key: AnyStr) -> "StreamEntryKey":
+    def parse_str(entry_key: AnyStr) -> StreamEntryKey:
         entry_key_str: str = entry_key.decode() if isinstance(entry_key, bytes) else entry_key
         parts = entry_key_str.split("-")
-        if not all([parts[i].isdigit() for i in range(len(parts))]):
+        if not all(parts[i].isdigit() for i in range(len(parts))):
             raise SimpleError("Invalid stream ID specified as stream command argument")
         (timestamp, sequence) = (int(parts[0]), 0) if len(parts) == 1 else (int(parts[0]), int(parts[1]))
         return StreamEntryKey(timestamp, sequence)
@@ -47,7 +51,7 @@ class PelEntry(NamedTuple):
 class StreamRangeTest:
     """Argument converter for sorted set LEX endpoints."""
 
-    def __init__(self, value: Union[StreamEntryKey, BeforeAny, AfterAny], exclusive: bool):
+    def __init__(self, value: StreamEntryKey | BeforeAny | AfterAny, exclusive: bool):
         self.value = value
         self.exclusive = exclusive
 
@@ -60,7 +64,7 @@ class StreamRangeTest:
             return False
 
     @classmethod
-    def decode(cls, value: bytes, exclusive: bool = False) -> "StreamRangeTest":
+    def decode(cls, value: bytes, exclusive: bool = False) -> StreamRangeTest:
         if value == b"-":
             return cls(BeforeAny(), True)
         elif value == b"+":
@@ -71,7 +75,7 @@ class StreamRangeTest:
 
 
 @dataclass
-class StreamConsumerInfo(object):
+class StreamConsumerInfo:
     name: bytes
     pending: int
     last_attempt: int  # Impacted by XREADGROUP, XCLAIM, XAUTOCLAIM
@@ -84,7 +88,7 @@ class StreamConsumerInfo(object):
         self.last_attempt = _time
         self.last_success = _time
 
-    def info(self, curr_time: int) -> Dict[str, Union[bytes, int]]:
+    def info(self, curr_time: int) -> dict[str, bytes | int]:
         return {
             "name": self.name,
             "pending": self.pending,
@@ -93,27 +97,27 @@ class StreamConsumerInfo(object):
         }
 
 
-class StreamGroup(object):
+class StreamGroup:
     def __init__(
         self,
-        stream: "XStream",
+        stream: XStream,
         name: bytes,
         start_key: StreamEntryKey,
-        entries_read: Optional[int] = None,
+        entries_read: int | None = None,
     ):
         self.stream = stream
         self.name = name
         self.start_key = start_key
         self.entries_read = entries_read
         # consumer_name -> #pending_messages
-        self.consumers: Dict[bytes, StreamConsumerInfo] = {}
+        self.consumers: dict[bytes, StreamConsumerInfo] = {}
         self.last_delivered_key = start_key
         self.last_ack_key = start_key
         # Pending entry List, see https://redis.io/commands/xreadgroup/
         # msg_id -> PelEntry(consumer_name, time_read, times_delivered)
-        self.pel: Dict[StreamEntryKey, PelEntry] = {}
+        self.pel: dict[StreamEntryKey, PelEntry] = {}
 
-    def set_id(self, last_delivered_str: bytes, entries_read: Optional[int]) -> None:
+    def set_id(self, last_delivered_str: bytes, entries_read: int | None) -> None:
         """Set last_delivered_id for the group"""
         self.start_key = self.stream.parse_ts_seq(last_delivered_str)
         (start_index, _) = self.stream.find_index(self.start_key)
@@ -133,13 +137,13 @@ class StreamGroup(object):
         del self.consumers[consumer_name]
         return res
 
-    def consumers_info(self) -> List[Dict[str, Union[bytes, int]]]:
+    def consumers_info(self) -> list[dict[str, bytes | int]]:
         return [self.consumers[k].info(current_time()) for k in self.consumers]
 
-    def group_info(self) -> Dict[bytes, Any]:
+    def group_info(self) -> dict[bytes, Any]:
         start_index, _ = self.stream.find_index(self.start_key)
         last_delivered_index, _ = self.stream.find_index(self.last_delivered_key)
-        last_ack_index, _ = self.stream.find_index(self.last_ack_key)
+        _last_ack_index, _ = self.stream.find_index(self.last_ack_key)
         if start_index + (self.entries_read or 0) > len(self.stream):
             lag = len(self.stream) - start_index - (self.entries_read or 0)
         else:
@@ -155,8 +159,8 @@ class StreamGroup(object):
         return res
 
     def group_read(
-        self, consumer_name: bytes, start_id: bytes, count: Optional[int], noack: bool
-    ) -> List[List[Union[bytes, List[bytes], None]]]:
+        self, consumer_name: bytes, start_id: bytes, count: int | None, noack: bool
+    ) -> list[list[bytes | list[bytes] | None]]:
         _time = current_time()
         if consumer_name not in self.consumers:
             self.consumers[consumer_name] = StreamConsumerInfo(consumer_name)
@@ -192,17 +196,17 @@ class StreamGroup(object):
             k: min(v, key=lambda x: x.time_read).time_read
             for k, v in itertools.groupby(self.pel.values(), key=lambda x: x.consumer_name)
         }
-        for consumer in new_last_success_map:
+        for consumer, last_success in new_last_success_map.items():
             if consumer not in self.consumers:
                 self.consumers[consumer] = StreamConsumerInfo(consumer)
-            self.consumers[consumer].last_attempt = new_last_success_map[consumer]
-            self.consumers[consumer].last_success = new_last_success_map[consumer]
+            self.consumers[consumer].last_attempt = last_success
+            self.consumers[consumer].last_success = last_success
 
     def nack_entries(
         self,
-        ids: List[bytes],
+        ids: list[bytes],
         mode: bytes,
-        retry_count: Optional[int] = None,
+        retry_count: int | None = None,
         force: bool = False,
     ) -> int:
         """Release PEL entries back to the group without acknowledging them.
@@ -248,7 +252,7 @@ class StreamGroup(object):
 
         return res
 
-    def ack(self, args: Tuple[bytes]) -> int:
+    def ack(self, args: tuple[bytes]) -> int:
         res = 0
         for k in args:
             try:
@@ -265,12 +269,12 @@ class StreamGroup(object):
 
     def pending(
         self,
-        idle: Optional[int],
-        start: Optional[StreamRangeTest],
-        end: Optional[StreamRangeTest],
-        count: Optional[int],
-        consumer: Optional[bytes],
-    ) -> List[List[Union[bytes, int]]]:
+        idle: int | None,
+        start: StreamRangeTest | None,
+        end: StreamRangeTest | None,
+        count: int | None,
+        consumer: bytes | None,
+    ) -> list[list[bytes | int]]:
         _time = current_time()
         relevant_ids = list(self.pel.keys())
         if consumer is not None:
@@ -301,7 +305,7 @@ class StreamGroup(object):
             for k in relevant_ids
         ]
 
-    def pending_summary(self) -> List[Any]:
+    def pending_summary(self) -> list[Any]:
         # XNACK-released entries are unowned and are not counted under any consumer.
         counter = Counter([self.pel[k].consumer_name for k in self.pel if self.pel[k].consumer_name])
         data = [
@@ -315,11 +319,11 @@ class StreamGroup(object):
     def claim(
         self,
         min_idle_ms: int,
-        msgs: Union[Sequence[bytes], Sequence[StreamEntryKey]],
+        msgs: Sequence[bytes] | Sequence[StreamEntryKey],
         consumer_name: bytes,
-        _time: Optional[int],
+        _time: int | None,
         force: bool,
-    ) -> Tuple[List[StreamEntryKey], List[StreamEntryKey]]:
+    ) -> tuple[list[StreamEntryKey], list[StreamEntryKey]]:
         curr_time = current_time()
         if _time is None:
             _time = curr_time
@@ -353,7 +357,7 @@ class StreamGroup(object):
         self._calc_consumer_last_time()
         return sorted(claimed_msgs), sorted(deleted_msgs)
 
-    def claim_for_read(self, min_idle_ms: int, consumer_name: bytes, count: Optional[int]) -> List[List[Any]]:
+    def claim_for_read(self, min_idle_ms: int, consumer_name: bytes, count: int | None) -> list[list[Any]]:
         """Claim idle pending entries for `XREADGROUP ... CLAIM min-idle-time` (Redis 8.4).
 
         Entries pending for at least min_idle_ms milliseconds are re-assigned to consumer_name,
@@ -369,7 +373,7 @@ class StreamGroup(object):
         )
         if count is not None:
             candidates = candidates[:count]
-        res: List[List[Any]] = []
+        res: list[list[Any]] = []
         for key in candidates:
             if key not in self.stream:
                 continue  # Entries deleted from the stream are skipped but remain in the PEL
@@ -379,12 +383,12 @@ class StreamGroup(object):
                     self.consumers[entry.consumer_name].pending -= 1
                 self.consumers[consumer_name].pending += 1
             self.pel[key] = PelEntry(consumer_name, curr_time, entry.times_delivered + 1)
-            record: List[Any] = list(self.stream.format_record(key))
+            record: list[Any] = list(self.stream.format_record(key))
             record.extend([curr_time - entry.time_read, entry.times_delivered])
             res.append(record)
         return res
 
-    def read_pel_msgs(self, min_idle_ms: int, start: bytes, count: int) -> List[StreamEntryKey]:
+    def read_pel_msgs(self, min_idle_ms: int, start: bytes, count: int) -> list[StreamEntryKey]:
         start_key = StreamEntryKey.parse_str(start)
         curr_time = current_time()
         msgs = sorted([k for k in self.pel if (curr_time - self.pel[k].time_read >= min_idle_ms) and k >= start_key])
@@ -409,15 +413,15 @@ class XStream(BaseModel):
     _model_type = b"stream"
 
     def __init__(self) -> None:
-        self._ids: List[StreamEntryKey] = []
-        self._values_dict: Dict[StreamEntryKey, List[bytes]] = {}
-        self._groups: Dict[bytes, StreamGroup] = {}
+        self._ids: list[StreamEntryKey] = []
+        self._values_dict: dict[StreamEntryKey, list[bytes]] = {}
+        self._groups: dict[bytes, StreamGroup] = {}
         self._max_deleted_id = StreamEntryKey(0, 0)
         self._entries_added = 0
-        self._last_generated_id: Optional[bytes] = None
+        self._last_generated_id: bytes | None = None
         self._idmp_duration: int = 100
         self._idmp_max_size: int = 100
-        self._idmp_map: Dict[bytes, Dict[bytes, StreamEntryKey]] = dict()  # producer_id -> idempotent_id -> entry_key
+        self._idmp_map: dict[bytes, dict[bytes, StreamEntryKey]] = {}  # producer_id -> idempotent_id -> entry_key
         self._iids_added: int = 0
         self._iids_duplicates: int = 0
 
@@ -429,10 +433,10 @@ class XStream(BaseModel):
         if max_size is not None and 1 <= max_size <= 10000:
             self._idmp_max_size = max_size
 
-    def group_get(self, group_name: bytes) -> Optional[StreamGroup]:
+    def group_get(self, group_name: bytes) -> StreamGroup | None:
         return self._groups.get(group_name, None)
 
-    def group_add(self, name: bytes, start_key_str: bytes, entries_read: Optional[int]) -> None:
+    def group_add(self, name: bytes, start_key_str: bytes, entries_read: int | None) -> None:
         """Add a group listening to stream
 
         :param name: Group name
@@ -451,17 +455,17 @@ class XStream(BaseModel):
             return 1
         return 0
 
-    def groups_info(self) -> List[Dict[bytes, Any]]:
-        res: List[Dict[bytes, Any]] = []
+    def groups_info(self) -> list[dict[bytes, Any]]:
+        res: list[dict[bytes, Any]] = []
         for group in self._groups.values():
             group_res = group.group_info()
             res.append(group_res)
         return res
 
-    def stream_info(self, full: bool) -> List[Any]:
+    def stream_info(self, full: bool) -> list[Any]:
         iids_tracked = sum([len(v) for v in self._idmp_map.values()])
 
-        res: Dict[bytes, Any] = {
+        res: dict[bytes, Any] = {
             b"length": len(self._ids),
             b"groups": len(self._groups),
             b"first-entry": self.format_record(self._ids[0]) if len(self._ids) > 0 else None,
@@ -484,7 +488,7 @@ class XStream(BaseModel):
             res[b"groups"] = [g.group_info() for g in self._groups.values()]
         return list(itertools.chain(*res.items()))
 
-    def delete(self, lst: List[AnyStr]) -> int:
+    def delete(self, lst: list[AnyStr]) -> int:
         """Delete items from stream
 
         :param lst: List of IDs to delete, in the form of `timestamp-sequence`.
@@ -500,7 +504,7 @@ class XStream(BaseModel):
                 res += 1
         return res
 
-    def delete_ex(self, ids: List[bytes], mode: bytes) -> List[int]:
+    def delete_ex(self, ids: list[bytes], mode: bytes) -> list[int]:
         """Extended delete with consumer-group reference control.
 
         mode: b'KEEPREF' preserve PEL refs, b'DELREF' remove all PEL refs,
@@ -516,10 +520,9 @@ class XStream(BaseModel):
 
             entry_key = self._ids[ind]
 
-            if mode == b"ACKED":
-                if any(entry_key in g.pel for g in self._groups.values()):
-                    results.append(2)
-                    continue
+            if mode == b"ACKED" and any(entry_key in g.pel for g in self._groups.values()):
+                results.append(2)
+                continue
 
             self._max_deleted_id = max(entry_key, self._max_deleted_id)
             del self._values_dict[entry_key]
@@ -537,7 +540,7 @@ class XStream(BaseModel):
 
         return results
 
-    def ackdel(self, group: "StreamGroup", ids: List[bytes], mode: bytes) -> List[int]:
+    def ackdel(self, group: StreamGroup, ids: list[bytes], mode: bytes) -> list[int]:
         """Atomically acknowledge in group and conditionally delete.
 
         Returns per-ID: -1 not found, 1 acked+deleted, 2 acked but not deleted (ACKED mode)
@@ -555,10 +558,9 @@ class XStream(BaseModel):
                 continue
             group.ack((id_bytes,))
 
-            if mode == b"ACKED":
-                if any(entry_key in g.pel for g in self._groups.values()):
-                    results.append(2)
-                    continue
+            if mode == b"ACKED" and any(entry_key in g.pel for g in self._groups.values()):
+                results.append(2)
+                continue
 
             self._max_deleted_id = max(entry_key, self._max_deleted_id)
             del self._values_dict[entry_key]
@@ -598,11 +600,11 @@ class XStream(BaseModel):
 
     def add(
         self,
-        fields: Sequence[Union[bytes, int]],
+        fields: Sequence[bytes | int],
         entry_key: str = "*",
-        producer_id: Optional[bytes] = None,
-        idempotent_id: Optional[bytes] = None,
-    ) -> Union[None, bytes]:
+        producer_id: bytes | None = None,
+        idempotent_id: bytes | None = None,
+    ) -> None | bytes:
         """Add entry to a stream.
 
         If the entry_key cannot be added (because its timestamp is before the last entry, etc.),
@@ -664,7 +666,7 @@ class XStream(BaseModel):
         self._last_generated_id = ts_seq.encode()
         if producer_id is not None and idempotent_id is not None:
             if producer_id not in self._idmp_map:
-                self._idmp_map[producer_id] = dict()
+                self._idmp_map[producer_id] = {}
             self._idmp_map[producer_id][idempotent_id] = ts_seq
             self._iids_added += 1
         return ts_seq.encode()
@@ -675,14 +677,14 @@ class XStream(BaseModel):
     def __len__(self) -> int:
         return len(self._ids)
 
-    def __iter__(self) -> Generator[List[Union[bytes, List[bytes]]], Any, None]:
-        def gen() -> Generator[List[Union[bytes, List[bytes]]], Any, None]:
+    def __iter__(self) -> Generator[list[bytes | list[bytes]], Any, None]:
+        def gen() -> Generator[list[bytes | list[bytes]], Any, None]:
             for k in self._ids:
                 yield self.format_record(k)
 
         return gen()
 
-    def __getitem__(self, key: bytes) -> Union[StreamEntryKey, List[bytes]]:
+    def __getitem__(self, key: bytes) -> StreamEntryKey | list[bytes]:
         return self._values_dict[StreamEntryKey.parse_str(key)]
 
     def get_index(self, ind: int) -> StreamEntryKey:
@@ -691,7 +693,7 @@ class XStream(BaseModel):
     def __contains__(self, key: StreamEntryKey) -> bool:
         return key in self._values_dict
 
-    def find_index(self, entry_key: StreamEntryKey, from_left: bool = True) -> Tuple[int, bool]:
+    def find_index(self, entry_key: StreamEntryKey, from_left: bool = True) -> tuple[int, bool]:
         """Find the closest index to entry_key_str in the stream
         :param entry_key: Key for the entry.
         :param from_left: If not found exact match, return index of last smaller element
@@ -709,7 +711,7 @@ class XStream(BaseModel):
             check_idx = ind - 1
         return ind, (check_idx < len(self._ids) and self._ids[check_idx] == entry_key)
 
-    def find_index_key_as_str(self, entry_key_str: AnyStr) -> Tuple[int, bool]:
+    def find_index_key_as_str(self, entry_key_str: AnyStr) -> tuple[int, bool]:
         """Find the closest index to entry_key_str in the stream
         :param entry_key_str: key for the entry, formatted as 'timestamp-sequence.'
         :returns: A tuple
@@ -729,9 +731,9 @@ class XStream(BaseModel):
 
     def trim(
         self,
-        max_length: Optional[int] = None,
-        start_entry_key: Optional[str] = None,
-        limit: Optional[int] = None,
+        max_length: int | None = None,
+        start_entry_key: str | None = None,
+        limit: int | None = None,
     ) -> int:
         """Trim a stream
 
@@ -743,11 +745,11 @@ class XStream(BaseModel):
         """
         if max_length is not None and start_entry_key is not None:
             raise ValueError("Can not use both max_length and start_entry_key")
-        start_ind: Optional[int] = None
+        start_ind: int | None = None
         if max_length is not None:
             start_ind = len(self._ids) - max_length
         elif start_entry_key is not None:
-            ind, exact = self.find_index_key_as_str(start_entry_key)
+            ind, _exact = self.find_index_key_as_str(start_entry_key)
             start_ind = ind
         res: int = min(max(start_ind or 0, 0), limit or sys.maxsize)
 
@@ -756,7 +758,7 @@ class XStream(BaseModel):
             del self._values_dict[k]
         return res
 
-    def irange(self, start: StreamRangeTest, stop: StreamRangeTest, reverse: bool = False) -> List[Any]:
+    def irange(self, start: StreamRangeTest, stop: StreamRangeTest, reverse: bool = False) -> list[Any]:
         """Returns a range of the stream values from start to stop.
 
         :param start: Start key
@@ -783,9 +785,9 @@ class XStream(BaseModel):
         return matches
 
     def last_item_key(self) -> bytes:
-        return self._ids[-1].encode() if len(self._ids) > 0 else "0-0".encode()
+        return self._ids[-1].encode() if len(self._ids) > 0 else b"0-0"
 
-    def stream_read(self, start_key: StreamEntryKey, count: Union[int, None]) -> List[StreamEntryKey]:
+    def stream_read(self, start_key: StreamEntryKey, count: int | None) -> list[StreamEntryKey]:
         start_ind, found = self.find_index(start_key)
         if found:
             start_ind += 1
@@ -794,7 +796,7 @@ class XStream(BaseModel):
         end_ind = len(self) if count is None or start_ind + count >= len(self) else start_ind + count
         return self._ids[start_ind:end_ind]
 
-    def format_record(self, key: StreamEntryKey) -> List[Union[bytes, List[bytes]]]:
+    def format_record(self, key: StreamEntryKey) -> list[bytes | list[bytes]]:
         # results: Dict[bytes, bytes] = dict(zip(*[iter(self._values_dict[key])] * 2))
         results = self._values_dict[key]
         return [key.encode(), results]

--- a/fakeredis/model/_timeseries_model.py
+++ b/fakeredis/model/_timeseries_model.py
@@ -1,7 +1,10 @@
-from typing import List, Dict, Tuple, Union, Optional, Callable
+from __future__ import annotations
+
+from typing import Callable
 
 from fakeredis import _msgs as msgs
 from fakeredis._helpers import Database, SimpleError
+
 from ._base_type import BaseModel
 
 
@@ -18,8 +21,8 @@ class TimeSeries(BaseModel):
         duplicate_policy: bytes = b"block",
         ignore_max_time_diff: int = 0,
         ignore_max_val_diff: int = 0,
-        labels: Optional[Dict[bytes, bytes]] = None,
-        source_key: Optional[bytes] = None,
+        labels: dict[bytes, bytes] | None = None,
+        source_key: bytes | None = None,
     ):
         super().__init__()
         self.name = name
@@ -28,16 +31,16 @@ class TimeSeries(BaseModel):
         self.encoding = encoding
         self.chunk_size = chunk_size
         self.duplicate_policy = duplicate_policy
-        self.ts_ind_map: Dict[int, int] = {}  # Map from timestamp to index in sorted_list
-        self.sorted_list: List[Tuple[int, float]] = []
+        self.ts_ind_map: dict[int, int] = {}  # Map from timestamp to index in sorted_list
+        self.sorted_list: list[tuple[int, float]] = []
         self.max_timestamp: int = 0
-        self.labels: Dict[bytes, bytes] = labels or {}
+        self.labels: dict[bytes, bytes] = labels or {}
         self.source_key = source_key
         self.ignore_max_time_diff = ignore_max_time_diff
         self.ignore_max_val_diff = ignore_max_val_diff
-        self.rules: List[TimeSeriesRule] = []
+        self.rules: list[TimeSeriesRule] = []
 
-    def add(self, timestamp: int, value: float, duplicate_policy: Optional[bytes] = None) -> Union[int, None]:
+    def add(self, timestamp: int, value: float, duplicate_policy: bytes | None = None) -> int | None:
         if self.retention != 0 and self.max_timestamp - timestamp > self.retention:
             raise SimpleError(msgs.TIMESERIES_TIMESTAMP_OLDER_THAN_RETENTION)
         if duplicate_policy is None:
@@ -63,7 +66,7 @@ class TimeSeries(BaseModel):
         self.max_timestamp = max(self.max_timestamp, timestamp)
         return timestamp
 
-    def incrby(self, timestamp: int, value: float) -> Union[int, None]:
+    def incrby(self, timestamp: int, value: float) -> int | None:
         if len(self.sorted_list) == 0:
             return self.add(timestamp, value)
         if timestamp == self.max_timestamp:
@@ -77,7 +80,7 @@ class TimeSeries(BaseModel):
 
         return timestamp
 
-    def get(self) -> Optional[List[Union[int, float]]]:
+    def get(self) -> list[int | float] | None:
         if len(self.sorted_list) == 0:
             return None
         ind = self.ts_ind_map[self.max_timestamp]
@@ -89,16 +92,16 @@ class TimeSeries(BaseModel):
         self.ts_ind_map = {k: v for k, v in self.ts_ind_map.items() if not (from_ts <= k <= to_ts)}
         return prev_size - len(self.sorted_list)
 
-    def get_rule(self, dest_key: bytes) -> Optional["TimeSeriesRule"]:
+    def get_rule(self, dest_key: bytes) -> TimeSeriesRule | None:
         for rule in self.rules:
             if rule.dest_key.name == dest_key:
                 return rule
         return None
 
-    def add_rule(self, rule: "TimeSeriesRule") -> None:
+    def add_rule(self, rule: TimeSeriesRule) -> None:
         self.rules.append(rule)
 
-    def delete_rule(self, rule: "TimeSeriesRule") -> None:
+    def delete_rule(self, rule: TimeSeriesRule) -> None:
         self.rules.remove(rule)
         rule.dest_key.source_key = None
 
@@ -106,15 +109,15 @@ class TimeSeries(BaseModel):
         self,
         from_ts: int,
         to_ts: int,
-        value_min: Optional[float],
-        value_max: Optional[float],
-        count: Optional[int],
-        filter_ts: Optional[List[int]],
+        value_min: float | None,
+        value_max: float | None,
+        count: int | None,
+        filter_ts: list[int] | None,
         reverse: bool,
-    ) -> List[Tuple[int, float]]:
+    ) -> list[tuple[int, float]]:
         value_min = value_min or float("-inf")
         value_max = value_max or float("inf")
-        res: List[Tuple[int, float]] = [
+        res: list[tuple[int, float]] = [
             x
             for x in self.sorted_list
             if (from_ts <= x[0] <= to_ts)
@@ -132,17 +135,17 @@ class TimeSeries(BaseModel):
         from_ts: int,
         to_ts: int,
         latest: bool,
-        value_min: Optional[float],
-        value_max: Optional[float],
-        count: Optional[int],
-        filter_ts: Optional[List[int]],
-        align: Optional[int],
+        value_min: float | None,
+        value_max: float | None,
+        count: int | None,
+        filter_ts: list[int] | None,
+        align: int | None,
         aggregator: bytes,
         bucket_duration: int,
-        bucket_timestamp: Optional[bytes],
-        empty: Optional[bool],
+        bucket_timestamp: bytes | None,
+        empty: bool | None,
         reverse: bool,
-    ) -> List[Tuple[int, float]]:
+    ) -> list[tuple[int, float]]:
         align = align or 0
         value_min = value_min or float("-inf")
         value_max = value_max or float("inf")
@@ -168,29 +171,29 @@ class TimeSeries(BaseModel):
 
 class Aggregators:
     @staticmethod
-    def var_p(values: List[float]) -> float:
+    def var_p(values: list[float]) -> float:
         if len(values) == 0:
             return 0
         avg = sum(values) / len(values)
         return sum((x - avg) ** 2 for x in values) / len(values)
 
     @staticmethod
-    def var_s(values: List[float]) -> float:
+    def var_s(values: list[float]) -> float:
         if len(values) == 0:
             return 0
         avg = sum(values) / len(values)
         return sum((x - avg) ** 2 for x in values) / (len(values) - 1)
 
     @staticmethod
-    def std_p(values: List[float]) -> float:
+    def std_p(values: list[float]) -> float:
         return float(Aggregators.var_p(values) ** 0.5)
 
     @staticmethod
-    def std_s(values: List[float]) -> float:
+    def std_s(values: list[float]) -> float:
         return float(Aggregators.var_s(values) ** 0.5)
 
 
-AGGREGATORS: Dict[bytes, Callable[[List[float]], float]] = {
+AGGREGATORS: dict[bytes, Callable[[list[float]], float]] = {
     b"avg": lambda x: sum(x) / len(x),
     b"sum": sum,
     b"min": min,
@@ -208,7 +211,7 @@ AGGREGATORS: Dict[bytes, Callable[[List[float]], float]] = {
 
 
 def apply_aggregator(
-    bucket: List[Tuple[int, float]], bucket_start_ts: int, bucket_duration: int, aggregator: bytes
+    bucket: list[tuple[int, float]], bucket_start_ts: int, bucket_duration: int, aggregator: bytes
 ) -> float:
     if len(bucket) == 0:
         return 0.0
@@ -223,7 +226,7 @@ def apply_aggregator(
 
         return total / bucket_duration
 
-    relevant_values: List[float] = [x[1] for x in bucket]
+    relevant_values: list[float] = [x[1] for x in bucket]
     return AGGREGATORS[aggregator](relevant_values)
 
 
@@ -242,11 +245,11 @@ class TimeSeriesRule:
         self.bucket_duration = bucket_duration
         self.align_timestamp = align_timestamp
         self.current_bucket_start_ts: int = 0
-        self.current_bucket: List[Tuple[int, float]] = []
+        self.current_bucket: list[tuple[int, float]] = []
         self.dest_key.source_key = source_key.name
 
-    def add_record(self, record: Tuple[int, float], bucket_timestamp: Optional[bytes] = None) -> bool:
-        ts, val = record
+    def add_record(self, record: tuple[int, float], bucket_timestamp: bytes | None = None) -> bool:
+        ts, _val = record
         bucket_start_ts = ts - (ts % self.bucket_duration) + self.align_timestamp
         if self.current_bucket_start_ts == bucket_start_ts:
             self.current_bucket.append(record)
@@ -266,7 +269,7 @@ class TimeSeriesRule:
             return True
         return False
 
-    def apply_curr_bucket(self, bucket_timestamp: Optional[bytes] = None) -> None:
+    def apply_curr_bucket(self, bucket_timestamp: bytes | None = None) -> None:
         if len(self.current_bucket) == 0:
             return
         value = apply_aggregator(

--- a/fakeredis/model/_topk.py
+++ b/fakeredis/model/_topk.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import heapq
 import random
 import time
-from typing import List, Optional, Tuple
 
 from ._base_type import BaseModel
 
 
-class Bucket(object):
+class Bucket:
     def __init__(self, counter: int, fingerprint: int):
         self.counter = counter
         self.fingerprint = fingerprint
@@ -35,7 +36,7 @@ class Bucket(object):
                 self.counter -= 1
 
 
-class HashArray(object):
+class HashArray:
     def __init__(self, width: int, decay: float):
         self.width = width
         self.decay = decay
@@ -68,7 +69,7 @@ class HeavyKeeper(BaseModel):
         self.depth = depth
         self.decay = decay
         self.hash_arrays = [HashArray(width, decay) for _ in range(depth)]
-        self.min_heap: List[Tuple[int, bytes]] = []
+        self.min_heap: list[tuple[int, bytes]] = []
 
     def _index(self, val: bytes) -> int:
         for ind, item in enumerate(self.min_heap):
@@ -76,7 +77,7 @@ class HeavyKeeper(BaseModel):
                 return ind
         return -1
 
-    def add(self, item: bytes, incr: int) -> Optional[bytes]:
+    def add(self, item: bytes, incr: int) -> bytes | None:
         max_count = 0
         for i in range(self.depth):
             count = self.hash_arrays[i].add(item, incr)
@@ -100,7 +101,7 @@ class HeavyKeeper(BaseModel):
             return self.min_heap[ind][0]
         return max([ha.count(item) for ha in self.hash_arrays])
 
-    def list(self, k: Optional[int] = None) -> List[Tuple[int, bytes]]:
+    def list(self, k: int | None = None) -> list[tuple[int, bytes]]:
         sorted_list = sorted(self.min_heap, key=lambda x: x[0], reverse=True)
         if k is None:
             return sorted_list

--- a/fakeredis/model/_vectorset.py
+++ b/fakeredis/model/_vectorset.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import json
 import math
 import re
 import struct
 from collections import OrderedDict
+from collections.abc import Iterator
 from functools import lru_cache
-from typing import List, Dict, Any, Literal, Optional, Iterator, Self, Union, Set
+from typing import Any, Literal
 
 import numpy as np
 from jsonpath_ng import JSONPath
@@ -13,11 +16,12 @@ from jsonpath_ng.ext import parse
 
 from fakeredis import _msgs as msgs
 from fakeredis._helpers import SimpleError
+from fakeredis._typing import Self
 
 QUANTIZATION_TYPE = Literal["noquant", "bin", "int8"]
 
 
-def _update_to_jsonpath_format(path: Union[bytes, str]) -> str:
+def _update_to_jsonpath_format(path: bytes | str) -> str:
     path_str = path.decode() if isinstance(path, bytes) else path
     path_str = re.sub(r"\band\b", "&", path_str)
     path_str = re.sub(r"\bor\b", "|", path_str)
@@ -36,7 +40,7 @@ def _update_to_jsonpath_format(path: Union[bytes, str]) -> str:
 
 
 @lru_cache(maxsize=64)
-def _parse_jsonfilter(path: Union[str, bytes]) -> JSONPath:
+def _parse_jsonfilter(path: str | bytes) -> JSONPath:
     path_str: str = _update_to_jsonpath_format(path)
     try:
         return parse(path_str)
@@ -46,7 +50,7 @@ def _parse_jsonfilter(path: Union[str, bytes]) -> JSONPath:
 
 class Vector:
     def __init__(
-        self, name: bytes, values: List[float], attributes: Optional[bytes], quantization: QUANTIZATION_TYPE, ef: int
+        self, name: bytes, values: list[float], attributes: bytes | None, quantization: QUANTIZATION_TYPE, ef: int
     ) -> None:
         self.name = name
         self.values = values
@@ -67,10 +71,10 @@ class Vector:
         return hash(self.name)
 
     @classmethod
-    def from_vector_values(cls, values: List[float]) -> Self:
+    def from_vector_values(cls, values: list[float]) -> Self:
         return cls(b"", values, b"", "int8", 0)
 
-    def raw(self) -> List[Any]:
+    def raw(self) -> list[Any]:
         raw_bytes = struct.pack(f"{len(self.values)}f", *self.values)
         if self.quantization == "int8":
             norm_values = np.array(self.values) / self.l2_norm if self.l2_norm != 0 else np.array(self.values)
@@ -92,13 +96,13 @@ class Vector:
 class VectorSet:
     def __init__(self, dimensions: int):
         self._dimensions = dimensions
-        self._vectors: Dict[bytes, Vector] = dict()
-        self._links: Dict[bytes, int] = dict()
-        self._quant_type: Optional[str] = None
+        self._vectors: dict[bytes, Vector] = {}
+        self._links: dict[bytes, int] = {}
+        self._quant_type: str | None = None
         self._node_uid_counter: int = 0
         self._max_level: int = 0
-        self._node_levels: Dict[bytes, int] = dict()
-        self._node_links: Dict[bytes, Dict[int, Set[bytes]]] = dict()
+        self._node_levels: dict[bytes, int] = {}
+        self._node_links: dict[bytes, dict[int, set[bytes]]] = {}
 
     @staticmethod
     def _compute_level(node_index: int, m: int) -> int:
@@ -114,7 +118,7 @@ class VectorSet:
     def card(self) -> int:
         return len(self._vectors)
 
-    def vector_names(self) -> List[bytes]:
+    def vector_names(self) -> list[bytes]:
         return list(self._vectors.keys())
 
     def exists(self, name: bytes) -> bool:
@@ -129,8 +133,7 @@ class VectorSet:
 
         level = self._compute_level(node_index, numlinks)
         self._node_levels[vector.name] = level
-        if level > self._max_level:
-            self._max_level = level
+        self._max_level = max(self._max_level, level)
 
         # Build links for this node at each of its levels
         self._node_links[vector.name] = {}
@@ -171,7 +174,7 @@ class VectorSet:
                 neighbors.discard(name)
         return 1
 
-    def info(self) -> Dict[bytes, Any]:
+    def info(self) -> dict[bytes, Any]:
         quant = self._quant_type or b"fp32"
         # Normalize quantization type name for the info response
         if quant == "noquant":
@@ -185,7 +188,7 @@ class VectorSet:
             b"hnsw-max-node-uid": self._node_uid_counter,
         }
 
-    def links(self, name: bytes) -> Optional[Dict[int, List[bytes]]]:
+    def links(self, name: bytes) -> dict[int, list[bytes]] | None:
         if name not in self._vectors:
             return None
         node_links = self._node_links.get(name, {0: set()})
@@ -193,16 +196,16 @@ class VectorSet:
 
     def range(
         self,
-        min_value: Optional[bytes],
+        min_value: bytes | None,
         include_min: bool,
-        max_value: Optional[bytes],
+        max_value: bytes | None,
         include_max: bool,
-        count: Optional[int],
-    ) -> List[bytes]:
+        count: int | None,
+    ) -> list[bytes]:
         if count is not None and count < 0:
             count = None
-        res: List[bytes] = []
-        for name in self._vectors.keys():
+        res: list[bytes] = []
+        for name in self._vectors:
             if (min_value is None or name > min_value or (include_min and name == min_value)) and (
                 max_value is None or name < max_value or (include_max and name == max_value)
             ):
@@ -222,7 +225,7 @@ class VectorSet:
     def __iter__(self) -> Iterator[Vector]:
         return iter(self._vectors.values())
 
-    def get(self, k: bytes) -> Optional[Vector]:
+    def get(self, k: bytes) -> Vector | None:
         if k in self._vectors:
             return self._vectors[k]
         return None
@@ -230,11 +233,11 @@ class VectorSet:
     def top_similar(
         self,
         query: Vector,
-        filter_expression: Optional[bytes],
+        filter_expression: bytes | None,
         count: int,
-        epsilon: Optional[float],
-        filter_ef: Optional[int] = None,
-    ) -> "OrderedDict[Vector, float]":
+        epsilon: float | None,
+        filter_ef: int | None = None,
+    ) -> OrderedDict[Vector, float]:
         """Return the top-``count`` most similar vectors to ``query``.
 
         Vectors are examined in best-first order (most similar first), mimicking the
@@ -267,7 +270,7 @@ class VectorSet:
             max_effort = filter_ef
         threshold = None if epsilon is None else 1.0 - epsilon
 
-        results: "OrderedDict[Vector, float]" = OrderedDict()
+        results: OrderedDict[Vector, float] = OrderedDict()
         examined = 0
         for idx in order:
             if examined >= max_effort:
@@ -285,7 +288,7 @@ class VectorSet:
         return results
 
     @staticmethod
-    def _passes_filter(vector: Vector, parsed_filter: Optional[JSONPath]) -> bool:
+    def _passes_filter(vector: Vector, parsed_filter: JSONPath | None) -> bool:
         if parsed_filter is None:
             return True
         if vector.attributes is None:

--- a/fakeredis/model/_zset.py
+++ b/fakeredis/model/_zset.py
@@ -1,8 +1,12 @@
-from typing import Any, Tuple, Optional, Generator, Dict, ItemsView, Union, cast
+from __future__ import annotations
+
+from collections.abc import Generator, ItemsView
+from typing import Any, cast
 
 import sortedcontainers
 
 from fakeredis._commands import AfterAny, BeforeAny
+
 from ._base_type import BaseModel
 
 
@@ -10,7 +14,7 @@ class ZSet(BaseModel):
     _model_type = b"zset"
 
     def __init__(self) -> None:
-        self._bylex: Dict[bytes, float] = {}  # Maps value to score
+        self._bylex: dict[bytes, float] = {}  # Maps value to score
         self._byscore = sortedcontainers.SortedList()
 
     def __contains__(self, value: bytes) -> bool:
@@ -33,7 +37,7 @@ class ZSet(BaseModel):
     def __getitem__(self, key: bytes) -> float:
         return self._bylex[key]
 
-    def get(self, key: bytes, default: Optional[float] = None) -> Optional[float]:
+    def get(self, key: bytes, default: float | None = None) -> float | None:
         return self._bylex.get(key, default)
 
     def __len__(self) -> int:
@@ -80,9 +84,9 @@ class ZSet(BaseModel):
 
     def irange_lex(
         self,
-        start: Union[bytes, BeforeAny, AfterAny],
-        stop: Union[bytes, BeforeAny, AfterAny],
-        inclusive: Tuple[bool, bool] = (True, True),
+        start: bytes | BeforeAny | AfterAny,
+        stop: bytes | BeforeAny | AfterAny,
+        inclusive: tuple[bool, bool] = (True, True),
         reverse: bool = False,
     ) -> Any:
         if len(self._byscore) == 0:
@@ -93,10 +97,10 @@ class ZSet(BaseModel):
         it = self._byscore.irange(start_elem, stop_elem, inclusive=inclusive, reverse=reverse)
         return (item[1] for item in it)
 
-    def irange_score(self, start: Tuple[Any, bytes], stop: Tuple[Any, bytes], reverse: bool) -> Any:
+    def irange_score(self, start: tuple[Any, bytes], stop: tuple[Any, bytes], reverse: bool) -> Any:
         return self._byscore.irange(start, stop, reverse=reverse)
 
-    def rank(self, member: bytes) -> Tuple[int, float]:
+    def rank(self, member: bytes) -> tuple[int, float]:
         ind: int = self._byscore.index((self._bylex[member], member))
         return ind, self._byscore[ind][0]
 

--- a/fakeredis/server_specific_commands/dragonfly_mixin.py
+++ b/fakeredis/server_specific_commands/dragonfly_mixin.py
@@ -1,11 +1,11 @@
-from typing import Callable, Any
+from typing import Any, Callable
 
-from fakeredis._commands import command, Key, Int, CommandItem
+from fakeredis._commands import CommandItem, Int, Key, command
 from fakeredis._helpers import Database, current_time
 from fakeredis.model import ExpiringMembersSet
 
 
-class DragonflyCommandsMixin(object):
+class DragonflyCommandsMixin:
     _expireat: Callable[[CommandItem, int], int]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/fakeredis/stack/__init__.py
+++ b/fakeredis/stack/__init__.py
@@ -1,10 +1,11 @@
 from ._tdigest_mixin import TDigestCommandsMixin
 from ._timeseries_mixin import TimeSeriesCommandsMixin
-from ._topk_mixin import TopkCommandsMixin  # noqa: F401
+from ._topk_mixin import TopkCommandsMixin
 
 try:
     import numpy  # noqa: F401
-    from ._vectorset_mixin import VectorSetCommandsMixin  # noqa: F401
+
+    from ._vectorset_mixin import VectorSetCommandsMixin
 except ImportError:
 
     class VectorSetCommandsMixin:  # type: ignore
@@ -14,12 +15,13 @@ except ImportError:
 try:
     from jsonpath_ng.ext import parse  # noqa: F401
     from redis.commands.json.path import Path  # noqa: F401
-    from ._json_mixin import JSONCommandsMixin  # noqa: F401
+
+    from ._json_mixin import JSONCommandsMixin
 except ImportError as e:
     if e.name == "fakeredis.stack._json_mixin":
-        raise e
+        raise
 
-    class JSONCommandsMixin:  # type: ignore # noqa: E303
+    class JSONCommandsMixin:  # type: ignore
         pass
 
 
@@ -31,25 +33,25 @@ try:
     from ._cms_mixin import CMSCommandsMixin
 except ImportError as e:
     if e.name == "fakeredis.stack._bf_mixin" or e.name == "fakeredis.stack._cf_mixin":
-        raise e
+        raise
 
-    class BFCommandsMixin:  # type: ignore # noqa: E303
+    class BFCommandsMixin:  # type: ignore
         pass
 
-    class CFCommandsMixin:  # type: ignore # noqa: E303
+    class CFCommandsMixin:  # type: ignore
         pass
 
-    class CMSCommandsMixin:  # type: ignore # noqa: E303
+    class CMSCommandsMixin:  # type: ignore
         pass
 
 
 __all__ = [
-    "TopkCommandsMixin",
-    "JSONCommandsMixin",
     "BFCommandsMixin",
     "CFCommandsMixin",
     "CMSCommandsMixin",
+    "JSONCommandsMixin",
     "TDigestCommandsMixin",
     "TimeSeriesCommandsMixin",
+    "TopkCommandsMixin",
     "VectorSetCommandsMixin",
 ]

--- a/fakeredis/stack/_bf_mixin.py
+++ b/fakeredis/stack/_bf_mixin.py
@@ -1,18 +1,20 @@
 """Command mixin for emulating `redis-py`'s BF functionality."""
 
-from typing import Any, List, Union, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import command, Key, CommandItem, Float, Int
-from fakeredis._helpers import SimpleError, OK, casematch, SimpleString
+from fakeredis._commands import CommandItem, Float, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import ScalableBloomFilter
 
 
 class BFCommandsMixin(CommandsMixinBase):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super(BFCommandsMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def _bf_add(key: CommandItem, item: bytes) -> int:
@@ -33,7 +35,7 @@ class BFCommandsMixin(CommandsMixinBase):
         return key.value.elements_added  # type:ignore
 
     @command(name="BF.MADD", fixed=(Key(ScalableBloomFilter), bytes), repeat=(bytes,))
-    def bf_madd(self, key: CommandItem, *values: bytes) -> List[int]:
+    def bf_madd(self, key: CommandItem, *values: bytes) -> list[int]:
         res = [BFCommandsMixin._bf_add(key, value) for value in values]
         return res
 
@@ -42,7 +44,7 @@ class BFCommandsMixin(CommandsMixinBase):
         return BFCommandsMixin._bf_exist(key, value)
 
     @command(name="BF.MEXISTS", fixed=(Key(ScalableBloomFilter), bytes), repeat=(bytes,))
-    def bf_mexists(self, key: CommandItem, *values: bytes) -> List[int]:
+    def bf_mexists(self, key: CommandItem, *values: bytes) -> list[int]:
         res = [BFCommandsMixin._bf_exist(key, value) for value in values]
         return res
 
@@ -69,7 +71,7 @@ class BFCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="BF.INSERT", fixed=(Key(),), repeat=(bytes,))
-    def bf_insert(self, key: CommandItem, *args: bytes) -> List[int]:
+    def bf_insert(self, key: CommandItem, *args: bytes) -> list[int]:
         (capacity, error_rate, expansion, non_scaling, no_create), left_args = extract_args(
             args,
             ("+capacity", ".error", "+expansion", "nonscaling", "nocreate"),
@@ -98,7 +100,7 @@ class BFCommandsMixin(CommandsMixinBase):
         return res
 
     @command(name="BF.INFO", fixed=(Key(),), repeat=(bytes,))
-    def bf_info(self, key: CommandItem, *args: bytes) -> Union[Any, Dict[bytes, Any]]:
+    def bf_info(self, key: CommandItem, *args: bytes) -> Any | dict[bytes, Any]:
         if key.value is None or type(key.value) is not ScalableBloomFilter:
             raise SimpleError("...")
         if len(args) > 1:
@@ -133,7 +135,7 @@ class BFCommandsMixin(CommandsMixinBase):
         return {res_key: res}
 
     @command(name="BF.SCANDUMP", fixed=(Key(), Int), repeat=(), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
-    def bf_scandump(self, key: CommandItem, iterator: int) -> List[Any]:
+    def bf_scandump(self, key: CommandItem, iterator: int) -> list[Any]:
         if key.value is None:
             raise SimpleError(msgs.NOT_FOUND_MSG)
 

--- a/fakeredis/stack/_cf_mixin.py
+++ b/fakeredis/stack/_cf_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 from typing import Any
 

--- a/fakeredis/stack/_cf_mixin.py
+++ b/fakeredis/stack/_cf_mixin.py
@@ -1,10 +1,10 @@
 import io
-from typing import List, Any, Dict
+from typing import Any
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import command, CommandItem, Int, Key
-from fakeredis._helpers import SimpleError, OK, casematch, SimpleString
+from fakeredis._commands import CommandItem, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis.model import ScalableCuckooFilter
 
 
@@ -53,7 +53,7 @@ class CFCommandsMixin:
         return CFCommandsMixin._cf_exist(key, value)
 
     @command(name="CF.INFO", fixed=(Key(),), repeat=(), flags=msgs.FLAG_DO_NOT_CREATE)
-    def cf_info(self, key: CommandItem) -> Dict[bytes, Any]:
+    def cf_info(self, key: CommandItem) -> dict[bytes, Any]:
         if key.value is None or type(key.value) is not ScalableCuckooFilter:
             raise SimpleError("...")
         return {
@@ -68,7 +68,7 @@ class CFCommandsMixin:
         }
 
     @command(name="CF.INSERT", fixed=(Key(),), repeat=(bytes,))
-    def cf_insert(self, key: CommandItem, *args: bytes) -> List[int]:
+    def cf_insert(self, key: CommandItem, *args: bytes) -> list[int]:
         (capacity, no_create), left_args = extract_args(
             args, ("+capacity", "nocreate"), error_on_unexpected=False, left_from_first_unexpected=True
         )
@@ -88,7 +88,7 @@ class CFCommandsMixin:
         return res
 
     @command(name="CF.INSERTNX", fixed=(Key(),), repeat=(bytes,))
-    def cf_insertnx(self, key: CommandItem, *args: bytes) -> List[int]:
+    def cf_insertnx(self, key: CommandItem, *args: bytes) -> list[int]:
         (capacity, no_create), left_args = extract_args(
             args, ("+capacity", "nocreate"), error_on_unexpected=False, left_from_first_unexpected=True
         )
@@ -112,7 +112,7 @@ class CFCommandsMixin:
         return res
 
     @command(name="CF.MEXISTS", fixed=(Key(ScalableCuckooFilter), bytes), repeat=(bytes,))
-    def cf_mexists(self, key: CommandItem, *values: bytes) -> List[int]:
+    def cf_mexists(self, key: CommandItem, *values: bytes) -> list[int]:
         res = [CFCommandsMixin._cf_exist(key, value) for value in values]
         return res
 
@@ -125,7 +125,7 @@ class CFCommandsMixin:
     def cf_reserve(self, key: CommandItem, capacity: int, *args: bytes) -> SimpleString:
         if key.value is not None:
             raise SimpleError(msgs.ITEM_EXISTS_MSG)
-        (bucket_size, max_iterations, expansion), _ = extract_args(
+        (bucket_size, max_iterations, _expansion), _ = extract_args(
             args, ("+bucketsize", "+maxiterations", "+expansion")
         )
 
@@ -141,7 +141,7 @@ class CFCommandsMixin:
         repeat=(),
         flags=msgs.FLAG_LEAVE_EMPTY_VAL + msgs.FLAG_DO_NOT_CREATE,
     )
-    def cf_scandump(self, key: CommandItem, iterator: int) -> List[Any]:
+    def cf_scandump(self, key: CommandItem, iterator: int) -> list[Any]:
         if key.value is None:
             raise SimpleError(msgs.NOT_FOUND_MSG)
         f = io.BytesIO()

--- a/fakeredis/stack/_cms_mixin.py
+++ b/fakeredis/stack/_cms_mixin.py
@@ -1,5 +1,7 @@
 """Command mixin for emulating `redis-py`'s Count-min sketch functionality."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from fakeredis import _msgs as msgs

--- a/fakeredis/stack/_cms_mixin.py
+++ b/fakeredis/stack/_cms_mixin.py
@@ -1,10 +1,10 @@
 """Command mixin for emulating `redis-py`'s Count-min sketch functionality."""
 
-from typing import Tuple, List, Any, Dict
+from typing import Any
 
 from fakeredis import _msgs as msgs
-from fakeredis._commands import command, CommandItem, Int, Key, Float
-from fakeredis._helpers import OK, SimpleString, SimpleError, casematch
+from fakeredis._commands import CommandItem, Float, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import CountMinSketch
 
@@ -16,10 +16,10 @@ class CMSCommandsMixin(CommandsMixinBase):
         repeat=(bytes, bytes),
         flags=msgs.FLAG_DO_NOT_CREATE,
     )
-    def cms_incrby(self, key: CommandItem, *args: bytes) -> List[Tuple[bytes, int]]:
+    def cms_incrby(self, key: CommandItem, *args: bytes) -> list[tuple[bytes, int]]:
         if key.value is None:
             raise SimpleError("CMS: key does not exist")
-        pairs: List[Tuple[bytes, int]] = []
+        pairs: list[tuple[bytes, int]] = []
         for i in range(0, len(args), 2):
             try:
                 pairs.append((args[i], int(args[i + 1])))
@@ -30,7 +30,7 @@ class CMSCommandsMixin(CommandsMixinBase):
         return res
 
     @command(name="CMS.INFO", fixed=(Key(CountMinSketch),), repeat=(), flags=msgs.FLAG_DO_NOT_CREATE)
-    def cms_info(self, key: CommandItem) -> Dict[bytes, Any]:
+    def cms_info(self, key: CommandItem) -> dict[bytes, Any]:
         if key.value is None:
             raise SimpleError("CMS: key does not exist")
         return {
@@ -88,7 +88,7 @@ class CMSCommandsMixin(CommandsMixinBase):
         return OK
 
     @command(name="CMS.QUERY", fixed=(Key(CountMinSketch), bytes), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def cms_query(self, key: CommandItem, *items: bytes) -> List[int]:
+    def cms_query(self, key: CommandItem, *items: bytes) -> list[int]:
         if key.value is None:
             raise SimpleError("CMS: key does not exist")
         return [key.value.check(item) for item in items]

--- a/fakeredis/stack/_json_mixin.py
+++ b/fakeredis/stack/_json_mixin.py
@@ -1,27 +1,29 @@
 """Command mixin for emulating `redis-py`'s JSON functionality."""
 
+from __future__ import annotations
+
 import copy
 import itertools
 import json
 import struct
 from json import JSONDecodeError
-from typing import Any, Union, Dict, List, Optional, Callable, Tuple, Type
+from typing import Any, Callable, ClassVar
 
-from jsonpath_ng import Root, JSONPath
+from jsonpath_ng import JSONPath, Root
 from jsonpath_ng.exceptions import JsonPathParserError
 from jsonpath_ng.ext import parse
 
 from fakeredis import _helpers as helpers
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import Key, command, delete_keys, CommandItem, Int, Float
+from fakeredis._commands import CommandItem, Float, Int, Key, command, delete_keys
 from fakeredis._helpers import SimpleString
 from fakeredis._typing import JsonType
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import ZSet
 
 
-def _format_path(path: Union[bytes, str]) -> str:
+def _format_path(path: bytes | str) -> str:
     path_str = path.decode() if isinstance(path, bytes) else path
     if path_str == ".":
         return "$"
@@ -33,7 +35,7 @@ def _format_path(path: Union[bytes, str]) -> str:
         return "$." + path_str
 
 
-def _parse_jsonpath(path: Union[str, bytes]) -> JSONPath:
+def _parse_jsonpath(path: str | bytes) -> JSONPath:
     path_str: str = _format_path(path)
     try:
         return parse(path_str)
@@ -45,7 +47,7 @@ def _path_is_root(path: JSONPath) -> bool:
     return path == Root()  # type: ignore
 
 
-def _dict_deep_merge(source: JsonType, destination: Dict[str, Any]) -> Dict[str, Any]:
+def _dict_deep_merge(source: JsonType, destination: dict[str, Any]) -> dict[str, Any]:
     """Deep merge of two dictionaries"""
     if not isinstance(source, dict):
         return destination
@@ -76,7 +78,7 @@ class JSONObject:
             raise helpers.SimpleError(cls.DECODE_ERROR)
 
     @classmethod
-    def encode(cls, value: Any) -> Optional[bytes]:
+    def encode(cls, value: Any) -> bytes | None:
         """Serialize the supplied Python object into a valid, JSON-formatted byte-encoded string."""
         return json.dumps(value, default=str).encode() if value is not None else None
 
@@ -103,7 +105,7 @@ def _quantize_fp64(value: float) -> float:
 
 
 # FPHA type token -> (name used in error messages, quantizer)
-_FPHA_TYPES: Dict[bytes, Tuple[str, Callable[[float], float]]] = {
+_FPHA_TYPES: dict[bytes, tuple[str, Callable[[float], float]]] = {
     b"fp16": ("F16", _quantize_fp16),
     b"bf16": ("BF16", _quantize_bf16),
     b"fp32": ("F32", _quantize_fp32),
@@ -127,7 +129,7 @@ def _shortest_float_in_type(quantized: float, quantizer: Callable[[float], float
     return quantized
 
 
-def _number_token_positions(raw: bytes) -> List[Tuple[int, int]]:
+def _number_token_positions(raw: bytes) -> list[tuple[int, int]]:
     """Scan a JSON document for number tokens, returning (line, column-after-token) for each.
 
     Positions are 1-based, matching the `value out of range ... at line L column C` errors of real redis.
@@ -175,7 +177,7 @@ def _apply_fpha(value: JsonType, fpha_type: bytes, raw: bytes) -> JsonType:
     # Index of the current number in document order, used to locate the offending token on error.
     number_index = itertools.count()
 
-    def convert(item: Union[int, float]) -> float:
+    def convert(item: float) -> float:
         index = next(number_index)
         try:
             quantized = quantizer(float(item))
@@ -200,9 +202,9 @@ def _apply_fpha(value: JsonType, fpha_type: bytes, raw: bytes) -> JsonType:
 
 
 def _json_write_iterate(
-    method: Callable[[JsonType], Tuple[Optional[JsonType], Any, bool]],
+    method: Callable[[JsonType], tuple[JsonType | None, Any, bool]],
     key: CommandItem,
-    path_str: Union[str, bytes],
+    path_str: str | bytes,
     allow_result_none: bool = False,
 ) -> JsonType:
     """Implement json.* write commands.
@@ -216,7 +218,7 @@ def _json_write_iterate(
         raise helpers.SimpleError(msgs.JSON_PATH_NOT_FOUND_OR_NOT_STRING.format(path_str))
 
     curr_value = copy.deepcopy(key.value)
-    res: List[JsonType] = []
+    res: list[JsonType] = []
     for item in found_matches:
         new_value, res_val, update = method(item.value)
         if update:
@@ -236,11 +238,11 @@ def _json_write_iterate(
 
 
 def _json_read_iterate(
-    method: Callable[[JsonType], Optional[Any]],
+    method: Callable[[JsonType], Any | None],
     key: CommandItem,
     *args: Any,
     error_on_zero_matches: bool = False,
-) -> Union[List[Optional[Any]], Optional[Any]]:
+) -> list[Any | None] | Any | None:
     path_str = args[0] if len(args) > 0 else "$"
     if key.value is None:
         if path_str[0] == ord(b"$"):
@@ -265,13 +267,13 @@ def _json_read_iterate(
 class JSONCommandsMixin(CommandsMixinBase):
     """`CommandsMixin` for enabling RedisJSON compatibility in `fakeredis`."""
 
-    TYPES_EMPTY_VAL_DICT: Dict[Type[object], Any] = {
+    TYPES_EMPTY_VAL_DICT: ClassVar[dict[type[object], Any]] = {
         dict: {},
         int: 0,
         float: 0.0,
         list: [],
     }
-    TYPE_NAMES: Dict[Type[object], bytes] = {
+    TYPE_NAMES: ClassVar[dict[type[object], bytes]] = {
         dict: b"object",
         int: b"integer",
         float: b"number",
@@ -291,7 +293,7 @@ class JSONCommandsMixin(CommandsMixinBase):
     @staticmethod
     def _get_single(
         key: CommandItem,
-        path_str: Union[str, bytes],
+        path_str: str | bytes,
         always_return_list: bool = False,
         empty_list_as_none: bool = False,
     ) -> Any:
@@ -332,7 +334,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         return res
 
     @staticmethod
-    def _json_set(key: CommandItem, path_str: bytes, value: JsonType, *args: Any) -> Optional[SimpleString]:
+    def _json_set(key: CommandItem, path_str: bytes, value: JsonType, *args: Any) -> SimpleString | None:
         path = _parse_jsonpath(path_str)
         if key.value is not None and (type(key.value) is not dict) and not _path_is_root(path):
             raise helpers.SimpleError(msgs.JSON_WRONG_REDIS_TYPE)
@@ -353,13 +355,13 @@ class JSONCommandsMixin(CommandsMixinBase):
         repeat=(bytes,),
         flags=msgs.FLAG_LEAVE_EMPTY_VAL + msgs.FLAG_DO_NOT_CREATE,
     )
-    def json_set(self, key: CommandItem, path_str: bytes, value_bytes: bytes, *args: bytes) -> Optional[SimpleString]:
+    def json_set(self, key: CommandItem, path_str: bytes, value_bytes: bytes, *args: bytes) -> SimpleString | None:
         """Set the JSON value at key `name` under the `path` to `obj`.
 
         For more information see `JSON.SET <https://redis.io/commands/json.set>`_.
         """
-        fpha: Optional[bytes] = None
-        left_args: List[bytes] = []
+        fpha: bytes | None = None
+        left_args: list[bytes] = []
         i = 0
         while i < len(args):
             if helpers.casematch(args[i], b"fpha"):
@@ -382,13 +384,13 @@ class JSONCommandsMixin(CommandsMixinBase):
         return JSONCommandsMixin._json_set(key, path_str, value, *left_args)
 
     @command(name="JSON.GET", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
-    def json_get(self, key: CommandItem, *args: bytes) -> Optional[bytes]:
+    def json_get(self, key: CommandItem, *args: bytes) -> bytes | None:
         if key.value is None:
             return None
         paths = [arg for arg in args if not helpers.casematch(b"noescape", arg)]
         no_wrapping_array = len(paths) == 1 and paths[0][0] == ord(b".")
 
-        formatted_paths: List[str] = [_format_path(arg) for arg in args if not helpers.casematch(b"noescape", arg)]
+        formatted_paths: list[str] = [_format_path(arg) for arg in args if not helpers.casematch(b"noescape", arg)]
         path_values = [self._get_single(key, path, len(formatted_paths) > 1) for path in formatted_paths]
 
         # Emulate the behavior of `redis-py`:
@@ -401,7 +403,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         return JSONObject.encode(dict(zip(formatted_paths, path_values)))
 
     @command(name="JSON.MGET", fixed=(bytes,), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
-    def json_mget(self, *args: bytes) -> List[Optional[bytes]]:
+    def json_mget(self, *args: bytes) -> list[bytes | None]:
         if len(args) < 2:
             raise helpers.SimpleError(msgs.WRONG_ARGS_MSG6.format("json.mget"))
         path_str = args[-1]
@@ -411,7 +413,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         return result
 
     @command(name="JSON.TOGGLE", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
-    def json_toggle(self, key: CommandItem, *args: bytes) -> Union[List[Optional[bool]], Optional[bool]]:
+    def json_toggle(self, key: CommandItem, *args: bytes) -> list[bool | None] | bool | None:
         if key.value is None:
             raise helpers.SimpleError(msgs.JSON_KEY_NOT_FOUND)
         path_str = args[0] if len(args) > 0 else b"$"
@@ -419,7 +421,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         found_matches = path.find(key.value)
 
         curr_value = copy.deepcopy(key.value)
-        res: List[Optional[bool]] = []
+        res: list[bool | None] = []
         for item in found_matches:
             if type(item.value) is bool:
                 curr_value = item.full_path.update(curr_value, not item.value)
@@ -456,12 +458,12 @@ class JSONCommandsMixin(CommandsMixinBase):
     @command(name="JSON.STRAPPEND", fixed=(Key(), bytes), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_strappend(
         self, key: CommandItem, path_str: bytes, *args: bytes
-    ) -> Union[List[Optional[JsonType]], Optional[JsonType]]:
+    ) -> list[JsonType | None] | JsonType | None:
         if len(args) == 0:
             raise helpers.SimpleError(msgs.WRONG_ARGS_MSG6.format("json.strappend"))
         addition = JSONObject.decode(args[0])
 
-        def strappend(val: JsonType) -> Tuple[Optional[JsonType], Optional[int], bool]:
+        def strappend(val: JsonType) -> tuple[JsonType | None, int | None, bool]:
             if type(val) is str:
                 new_value = val + addition
                 return new_value, len(new_value), True
@@ -473,13 +475,13 @@ class JSONCommandsMixin(CommandsMixinBase):
     @command(name="JSON.ARRAPPEND", fixed=(Key(), bytes), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_arrappend(
         self, key: CommandItem, path_str: bytes, *args: bytes
-    ) -> Union[List[Optional[JsonType]], Optional[JsonType]]:
+    ) -> list[JsonType | None] | JsonType | None:
         if len(args) == 0:
             raise helpers.SimpleError(msgs.WRONG_ARGS_MSG6.format("json.arrappend"))
 
         addition = [JSONObject.decode(item) for item in args]
 
-        def arrappend(val: JsonType) -> Tuple[Optional[JsonType], Optional[int], bool]:
+        def arrappend(val: JsonType) -> tuple[JsonType | None, int | None, bool]:
             if type(val) is list:
                 new_value = val + addition
                 return new_value, len(new_value), True
@@ -491,13 +493,13 @@ class JSONCommandsMixin(CommandsMixinBase):
     @command(name="JSON.ARRINSERT", fixed=(Key(), bytes, Int), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_arrinsert(
         self, key: CommandItem, path_str: bytes, index: int, *args: bytes
-    ) -> Union[List[Optional[JsonType]], Optional[JsonType]]:
+    ) -> list[JsonType | None] | JsonType | None:
         if len(args) == 0:
             raise helpers.SimpleError(msgs.WRONG_ARGS_MSG6.format("json.arrinsert"))
 
         addition = [JSONObject.decode(item) for item in args]
 
-        def arrinsert(val: JsonType) -> Tuple[Optional[JsonType], Optional[int], bool]:
+        def arrinsert(val: JsonType) -> tuple[JsonType | None, int | None, bool]:
             if type(val) is list:
                 new_value = val[:index] + addition + val[index:]
                 return new_value, len(new_value), True
@@ -508,10 +510,10 @@ class JSONCommandsMixin(CommandsMixinBase):
 
     @command(name="JSON.ARRPOP", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_arrpop(self, key: CommandItem, *args: bytes) -> JsonType:
-        path_str: Union[bytes, str] = args[0] if len(args) > 0 else "$"
+        path_str: bytes | str = args[0] if len(args) > 0 else "$"
         index = Int.decode(args[1]) if len(args) > 1 else -1
 
-        def arrpop(val: JsonType) -> Tuple[JsonType, Optional[bytes], bool]:
+        def arrpop(val: JsonType) -> tuple[JsonType, bytes | None, bool]:
             if type(val) is list and len(val) > 0:
                 ind = index if index < len(val) else -1
                 res = val.pop(ind)
@@ -527,7 +529,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         start = Int.decode(args[1]) if len(args) > 1 else 0
         stop = Int.decode(args[2]) if len(args) > 2 else None
 
-        def arrtrim(val: JsonType) -> Tuple[Optional[JsonType], Optional[int], bool]:
+        def arrtrim(val: JsonType) -> tuple[JsonType | None, int | None, bool]:
             if type(val) is list:
                 start_ind = min(start, len(val))
                 stop_ind = len(val) if stop is None or stop == -1 else stop + 1
@@ -548,8 +550,8 @@ class JSONCommandsMixin(CommandsMixinBase):
     )
     def json_numincrby(
         self, key: CommandItem, path_str: bytes, inc_by: float, *_: bytes
-    ) -> Union[List[Optional[JsonType]], Optional[JsonType]]:
-        def numincrby(val: Optional[JsonType]) -> Tuple[Optional[JsonType], Optional[float], bool]:
+    ) -> list[JsonType | None] | JsonType | None:
+        def numincrby(val: JsonType | None) -> tuple[JsonType | None, float | None, bool]:
             if val is not None and type(val) in {int, float}:
                 new_value = val + inc_by  # type: ignore
                 return new_value, new_value, True
@@ -566,7 +568,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         flags=msgs.FLAG_LEAVE_EMPTY_VAL + msgs.FLAG_SKIP_CONVERT_TO_RESP2,
     )
     def json_nummultby(self, key: CommandItem, path_str: bytes, mult_by: float, *_: bytes) -> JsonType:
-        def nummultby(val: Optional[JsonType]) -> Tuple[Optional[JsonType], Optional[float], bool]:
+        def nummultby(val: JsonType | None) -> tuple[JsonType | None, float | None, bool]:
             if type(val) in {int, float}:
                 new_value = val * mult_by  # type: ignore
                 return new_value, new_value, True
@@ -584,7 +586,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         end = end if end > 0 else -1
         expected_value = JSONObject.decode(encoded_value)
 
-        def check_index(value: JsonType) -> Optional[int]:
+        def check_index(value: JsonType) -> int | None:
             if type(value) is not list:
                 return None
             try:
@@ -601,15 +603,15 @@ class JSONCommandsMixin(CommandsMixinBase):
         return _json_read_iterate(check_index, key, path_str, error_on_zero_matches=True)
 
     @command(name="JSON.STRLEN", fixed=(Key(),), repeat=(bytes,))
-    def json_strlen(self, key: CommandItem, *args: bytes) -> Union[List[Optional[int]], Optional[int]]:
+    def json_strlen(self, key: CommandItem, *args: bytes) -> list[int | None] | int | None:
         return _json_read_iterate(lambda val: len(val) if type(val) is str else None, key, *args)
 
     @command(name="JSON.ARRLEN", fixed=(Key(),), repeat=(bytes,))
-    def json_arrlen(self, key: CommandItem, *args: bytes) -> Union[List[Optional[int]], Optional[int]]:
+    def json_arrlen(self, key: CommandItem, *args: bytes) -> list[int | None] | int | None:
         return _json_read_iterate(lambda val: len(val) if type(val) is list else None, key, *args)
 
     @command(name="JSON.OBJLEN", fixed=(Key(),), repeat=(bytes,))
-    def json_objlen(self, key: CommandItem, *args: bytes) -> Union[List[Optional[int]], Optional[int]]:
+    def json_objlen(self, key: CommandItem, *args: bytes) -> list[int | None] | int | None:
         return _json_read_iterate(lambda val: len(val) if type(val) is dict else None, key, *args)
 
     def _resp3_wrapping_list(self, res: Any, wrap_list: bool = False) -> Any:
@@ -620,15 +622,13 @@ class JSONCommandsMixin(CommandsMixinBase):
         return [res]
 
     @command(name="JSON.TYPE", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
-    def json_type(self, key: CommandItem, *args: bytes) -> Union[List[Optional[bytes]], Optional[bytes]]:
+    def json_type(self, key: CommandItem, *args: bytes) -> list[bytes | None] | bytes | None:
         res = _json_read_iterate(lambda val: self.TYPE_NAMES.get(type(val), None), key, *args)
         return self._resp3_wrapping_list(res, wrap_list=True)  # type:ignore
 
     @command(name="JSON.OBJKEYS", fixed=(Key(),), repeat=(bytes,))
-    def json_objkeys(self, key: CommandItem, *args: bytes) -> Union[List[Optional[bytes]], Optional[bytes]]:
-        return _json_read_iterate(
-            lambda val: [i.encode() for i in val.keys()] if type(val) is dict else None, key, *args
-        )
+    def json_objkeys(self, key: CommandItem, *args: bytes) -> list[bytes | None] | bytes | None:
+        return _json_read_iterate(lambda val: [i.encode() for i in val] if type(val) is dict else None, key, *args)
 
     @command(name="JSON.MSET", fixed=(), repeat=(Key(), bytes, JSONObject), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_mset(self, *args: Any) -> SimpleString:

--- a/fakeredis/stack/_tdigest_mixin.py
+++ b/fakeredis/stack/_tdigest_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from fakeredis import _msgs as msgs

--- a/fakeredis/stack/_tdigest_mixin.py
+++ b/fakeredis/stack/_tdigest_mixin.py
@@ -1,9 +1,9 @@
-from typing import List, Dict, Any
+from typing import Any
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import command, CommandItem, Int, Key, Float
-from fakeredis._helpers import SimpleString, SimpleError, OK
+from fakeredis._commands import CommandItem, Float, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import TDigest
 
@@ -18,7 +18,7 @@ class TDigestCommandsMixin(CommandsMixinBase):
     def tdigest_create(self, key: CommandItem, *args: bytes) -> SimpleString:
         if key.value is not None:
             raise SimpleError(msgs.TDIGEST_KEY_EXISTS)
-        (compression,), left_args = extract_args(args, ("+compression",))
+        (compression,), _left_args = extract_args(args, ("+compression",))
         if compression is None:
             compression = 100
         key.update(TDigest(compression))
@@ -65,7 +65,7 @@ class TDigestCommandsMixin(CommandsMixinBase):
             raise SimpleError(msgs.WRONG_ARGS_MSG6.format("tdigest.merge"))
         sources_names = args[:numkeys]
         (compression, override), _ = extract_args(args[numkeys:], ("+compression", "override"))
-        sources: List[TDigest] = [self._db.get(name).value for name in sources_names if name in self._db]  # type:ignore
+        sources: list[TDigest] = [self._db.get(name).value for name in sources_names if name in self._db]  # type:ignore
         if len(sources) != len(sources_names):
             raise SimpleError(msgs.TDIGEST_KEY_NOT_EXISTS)
 
@@ -107,7 +107,7 @@ class TDigestCommandsMixin(CommandsMixinBase):
         repeat=(Float,),
         flags=msgs.FLAG_DO_NOT_CREATE + msgs.FLAG_LEAVE_EMPTY_VAL,
     )
-    def tdigest_rank(self, key: CommandItem, *values: float) -> List[int]:
+    def tdigest_rank(self, key: CommandItem, *values: float) -> list[int]:
         if key.value is None:
             raise SimpleError(msgs.TDIGEST_KEY_NOT_EXISTS)
         if len(key.value) == 0:
@@ -128,7 +128,7 @@ class TDigestCommandsMixin(CommandsMixinBase):
         repeat=(Float,),
         flags=msgs.FLAG_DO_NOT_CREATE + msgs.FLAG_LEAVE_EMPTY_VAL,
     )
-    def tdigest_revrank(self, key: CommandItem, *values: float) -> List[int]:
+    def tdigest_revrank(self, key: CommandItem, *values: float) -> list[int]:
         if key.value is None:
             raise SimpleError(msgs.TDIGEST_KEY_NOT_EXISTS)
         if len(key.value) == 0:
@@ -148,12 +148,12 @@ class TDigestCommandsMixin(CommandsMixinBase):
         repeat=(Float,),
         flags=msgs.FLAG_DO_NOT_CREATE + msgs.FLAG_LEAVE_EMPTY_VAL,
     )
-    def tdigest_quantile(self, key: CommandItem, *quantiles: float) -> List[float]:
+    def tdigest_quantile(self, key: CommandItem, *quantiles: float) -> list[float]:
         if key.value is None:
             raise SimpleError(msgs.TDIGEST_KEY_NOT_EXISTS)
         if len(key.value) <= 1:
             return [float("nan")]
-        res: List[float] = []
+        res: list[float] = []
         for q in quantiles:
             if q < 0 or q > 1:
                 raise SimpleError(msgs.TDIGEST_BAD_QUANTILE)
@@ -169,13 +169,13 @@ class TDigestCommandsMixin(CommandsMixinBase):
         repeat=(Float,),
         flags=msgs.FLAG_DO_NOT_CREATE + msgs.FLAG_LEAVE_EMPTY_VAL,
     )
-    def tdigest_cdf(self, key: CommandItem, *values: float) -> List[float]:  # Cumulative Distribution Function
+    def tdigest_cdf(self, key: CommandItem, *values: float) -> list[float]:  # Cumulative Distribution Function
         """Returns, for each input value, an estimation of the fraction (floating-point) of
         (observations smaller than the given value + half the observations equal to the given value).
         """
         if key.value is None:
             raise SimpleError(msgs.TDIGEST_KEY_NOT_EXISTS)
-        res: List[float] = []
+        res: list[float] = []
         for v in values:
             left = key.value.bisect_left(v)
             right = key.value.bisect_right(v)
@@ -190,7 +190,7 @@ class TDigestCommandsMixin(CommandsMixinBase):
     @command(
         name="TDIGEST.INFO", fixed=(Key(TDigest),), repeat=(), flags=msgs.FLAG_DO_NOT_CREATE + msgs.FLAG_LEAVE_EMPTY_VAL
     )
-    def tdigest_info(self, key: CommandItem) -> Dict[bytes, Any]:
+    def tdigest_info(self, key: CommandItem) -> dict[bytes, Any]:
         return {
             b"Compression": key.value.compression,
             b"Capacity": len(key.value),
@@ -229,12 +229,12 @@ class TDigestCommandsMixin(CommandsMixinBase):
         repeat=(Int,),
         flags=msgs.FLAG_DO_NOT_CREATE + msgs.FLAG_LEAVE_EMPTY_VAL,
     )
-    def tdigest_byrank(self, key: CommandItem, *ranks: int) -> List[float]:
+    def tdigest_byrank(self, key: CommandItem, *ranks: int) -> list[float]:
         if key.value is None:
             raise SimpleError(msgs.TDIGEST_KEY_NOT_EXISTS)
         if len(key.value) == 0:
             return [float("nan")]
-        res: List[float] = []
+        res: list[float] = []
         for rank in ranks:
             if rank < 0:
                 raise SimpleError(msgs.TDIGEST_BAD_RANK)
@@ -250,12 +250,12 @@ class TDigestCommandsMixin(CommandsMixinBase):
         repeat=(Int,),
         flags=msgs.FLAG_DO_NOT_CREATE + msgs.FLAG_LEAVE_EMPTY_VAL,
     )
-    def tdigest_byrevrank(self, key: CommandItem, *ranks: int) -> List[float]:
+    def tdigest_byrevrank(self, key: CommandItem, *ranks: int) -> list[float]:
         if key.value is None:
             raise SimpleError(msgs.TDIGEST_KEY_NOT_EXISTS)
         if len(key.value) == 0:
             return [float("nan")]
-        res: List[float] = []
+        res: list[float] = []
         for rank in ranks:
             if rank < 0:
                 raise SimpleError(msgs.TDIGEST_BAD_RANK)

--- a/fakeredis/stack/_timeseries_mixin.py
+++ b/fakeredis/stack/_timeseries_mixin.py
@@ -1,20 +1,22 @@
+from __future__ import annotations
+
 import sys
 import time
-from typing import List, Union, Optional, Any, Set, Dict, cast
+from typing import Any, ClassVar, cast
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import command, Key, CommandItem, Int, Float
-from fakeredis._helpers import SimpleString, OK, SimpleError, casematch
+from fakeredis._commands import CommandItem, Float, Int, Key, command
+from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
-from fakeredis.model import TimeSeries, TimeSeriesRule, AGGREGATORS
+from fakeredis.model import AGGREGATORS, TimeSeries, TimeSeriesRule
 
 
 class Timestamp(Int):
     """Argument converter for timestamps"""
 
     @classmethod
-    def decode(cls, value: bytes, decode_error: Optional[str] = None) -> int:
+    def decode(cls, value: bytes, decode_error: str | None = None) -> int:
         if value == b"*":
             return int(time.time() * 1000)
         if value == b"-":
@@ -25,8 +27,8 @@ class Timestamp(Int):
 
 
 class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
-    _timeseries_keys: Set[bytes] = set()
-    DUPLICATE_POLICIES = [b"BLOCK", b"FIRST", b"LAST", b"MIN", b"MAX", b"SUM"]
+    _timeseries_keys: ClassVar[set[bytes]] = set()
+    DUPLICATE_POLICIES: ClassVar[list[bytes]] = [b"BLOCK", b"FIRST", b"LAST", b"MIN", b"MAX", b"SUM"]
 
     @staticmethod
     def _filter_expression_check(ts: TimeSeries, filter_expression: bytes) -> bool:
@@ -55,8 +57,8 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
             return label in ts.labels and ts.labels[label] == value
         raise SimpleError(msgs.TIMESERIES_BAD_FILTER_EXPRESSION)
 
-    def _get_timeseries(self, filter_expressions: List[bytes]) -> List["TimeSeries"]:
-        res: List["TimeSeries"] = []
+    def _get_timeseries(self, filter_expressions: list[bytes]) -> list[TimeSeries]:
+        res: list[TimeSeries] = []
         TimeSeriesCommandsMixin._timeseries_keys = {
             k for k in TimeSeriesCommandsMixin._timeseries_keys if k in self._db
         }
@@ -113,7 +115,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         return res
 
     @command(name="TS.INFO", fixed=(Key(TimeSeries),), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def ts_info(self, key: CommandItem, *args: bytes) -> Dict[bytes, Any]:
+    def ts_info(self, key: CommandItem, *args: bytes) -> dict[bytes, Any]:
         if key.value is None:
             raise SimpleError(msgs.TIMESERIES_KEY_DOES_NOT_EXIST)
         if self._client_info.protocol_version == 2:
@@ -154,7 +156,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
 
     @command(name="TS.ADD", fixed=(Key(TimeSeries), Timestamp, Float), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
     def ts_add(self, key: CommandItem, timestamp: int, value: float, *args: bytes) -> int:
-        (on_duplicate,), left_args = extract_args(args, ("*on_duplicate",), error_on_unexpected=False)
+        (on_duplicate,), _left_args = extract_args(args, ("*on_duplicate",), error_on_unexpected=False)
         if key.value is None:
             key.update(self._create_timeseries(key.key, *args))
         if not self._validate_duplicate_policy(on_duplicate):
@@ -162,7 +164,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         return cast(int, key.value.add(timestamp, value, on_duplicate))
 
     @command(name="TS.GET", fixed=(Key(TimeSeries),), repeat=(bytes,))
-    def ts_get(self, key: CommandItem, *args: bytes) -> Optional[List[Union[int, float]]]:
+    def ts_get(self, key: CommandItem, *args: bytes) -> list[int | float] | None:
         if key.value is None:
             raise SimpleError(msgs.TIMESERIES_KEY_DOES_NOT_EXIST)
         res = key.value.get()
@@ -176,10 +178,10 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         repeat=(Key(TimeSeries), Timestamp, Float),
         flags=msgs.FLAG_DO_NOT_CREATE,
     )
-    def ts_madd(self, *args: Any) -> List[Any]:
+    def ts_madd(self, *args: Any) -> list[Any]:
         if len(args) % 3 != 0:
             raise SimpleError(msgs.WRONG_ARGS_MSG6)
-        results: List[Any] = []
+        results: list[Any] = []
         for i in range(0, len(args), 3):
             key, timestamp, value = args[i : i + 3]
             if key.value is None:
@@ -237,7 +239,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
     def ts_deleterule(self, source_key: CommandItem, dest_key: CommandItem) -> SimpleString:
         if source_key.value is None:
             raise SimpleError(msgs.TIMESERIES_KEY_DOES_NOT_EXIST)
-        res: Optional[TimeSeriesRule] = source_key.value.get_rule(dest_key.key)
+        res: TimeSeriesRule | None = source_key.value.get_rule(dest_key.key)
         if res is None:
             raise SimpleError(msgs.TIMESERIES_RULE_DOES_NOT_EXIST)
         source_key.value.delete_rule(res)
@@ -306,9 +308,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         key.updated()
         return OK
 
-    def _range(
-        self, reverse: bool, ts: TimeSeries, from_ts: int, to_ts: int, *args: bytes
-    ) -> List[List[Union[int, float]]]:
+    def _range(self, reverse: bool, ts: TimeSeries, from_ts: int, to_ts: int, *args: bytes) -> list[list[int | float]]:
         RANGE_ARGS = ("latest", "++filter_by_value", "+count", "*align", "*+aggregation", "*buckettimestamp", "empty")
         (
             (
@@ -323,7 +323,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
             left_args,
         ) = extract_args(args, RANGE_ARGS, error_on_unexpected=False, left_from_first_unexpected=False)
         latest = True
-        filter_ts: Optional[List[int]] = None
+        filter_ts: list[int] | None = None
         if len(left_args) > 0:
             if not casematch(left_args[0], b"FILTER_BY_TS"):
                 raise SimpleError(msgs.WRONG_ARGS_MSG6)
@@ -345,7 +345,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
             return [[x[0], x[1]] for x in res]
 
         # Since redis 8.8, multiple comma-separated aggregators can be given in a single command.
-        aggregators: List[bytes] = aggregator.lower().split(b",")
+        aggregators: list[bytes] = aggregator.lower().split(b",")
         if any(agg not in AGGREGATORS for agg in aggregators):
             raise SimpleError(msgs.TIMESERIES_BAD_AGGREGATION_TYPE)
         if len(aggregators) > 1 and (self.version < (8, 8) or self.server_type != "redis"):
@@ -369,7 +369,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
             for agg in aggregators
         ]
         # Each bucket row is (timestamp, value-per-aggregator...); all aggregators share the same buckets.
-        result: List[List[Union[int, float]]] = [
+        result: list[list[int | float]] = [
             [row[0]] + [aggregated[j][i][1] for j in range(len(aggregators))] for i, row in enumerate(aggregated[0])
         ]
         return result
@@ -377,7 +377,7 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
     @command(
         name="TS.RANGE", fixed=(Key(TimeSeries), Timestamp, Timestamp), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE
     )
-    def ts_range(self, key: CommandItem, from_ts: int, to_ts: int, *args: bytes) -> List[List[Union[int, float]]]:
+    def ts_range(self, key: CommandItem, from_ts: int, to_ts: int, *args: bytes) -> list[list[int | float]]:
         if key.value is None:
             raise SimpleError(msgs.TIMESERIES_KEY_DOES_NOT_EXIST)
         return self._range(False, key.value, from_ts, to_ts, *args)
@@ -388,14 +388,14 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         repeat=(bytes,),
         flags=msgs.FLAG_DO_NOT_CREATE,
     )
-    def ts_revrange(self, key: CommandItem, from_ts: int, to_ts: int, *args: bytes) -> List[List[Union[int, float]]]:
+    def ts_revrange(self, key: CommandItem, from_ts: int, to_ts: int, *args: bytes) -> list[list[int | float]]:
         if key.value is None:
             raise SimpleError(msgs.TIMESERIES_KEY_DOES_NOT_EXIST)
         res = self._range(True, key.value, from_ts, to_ts, *args)
         return res
 
     @command(name="TS.MGET", fixed=(bytes,), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def ts_mget(self, *args: bytes) -> List[List[Union[bytes, List[List[Union[int, float]]]]]]:
+    def ts_mget(self, *args: bytes) -> list[list[bytes | list[list[int | float]]]]:
         latest, with_labels, selected_labels, filter_expression = False, False, None, None
         i = 0
         while i < len(args):
@@ -450,19 +450,19 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         return res  # type: ignore[no-any-return]
 
     @command(name="TS.QUERYINDEX", fixed=(bytes,), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def ts_queryindex(self, *args: bytes) -> List[bytes]:
+    def ts_queryindex(self, *args: bytes) -> list[bytes]:
         filter_expressions = list(args)
         timeseries = self._get_timeseries(filter_expressions)
         return [ts.name for ts in timeseries]
 
     def _group_by_label(
-        self, reverse: bool, ts_dict: Dict[bytes, List[Any]], label: bytes, reducer: bytes
-    ) -> Dict[bytes, List[Any]]:
+        self, reverse: bool, ts_dict: dict[bytes, list[Any]], label: bytes, reducer: bytes
+    ) -> dict[bytes, list[Any]]:
         # ts_dict: name -> [labels, ..., measurements]
         reducer = reducer.lower()
         if reducer not in AGGREGATORS:
             raise SimpleError(msgs.TIMESERIES_BAD_AGGREGATION_TYPE)
-        ts_map: Dict[bytes, Dict[int, List[float]]] = {}  # label_value -> timestamp -> values
+        ts_map: dict[bytes, dict[int, list[float]]] = {}  # label_value -> timestamp -> values
         for ts_data in ts_dict.values():
             # Find label value
             labels_dict = ts_data[0]
@@ -480,9 +480,9 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         for label_value, timestamp_values in ts_map.items():
             sorted_timestamps = sorted(timestamp_values.keys())
             name = f"{label.decode()}={label_value.decode()}"
-            sources = [ts_name.decode() for ts_name in ts_map.keys()]
+            sources = [ts_name.decode() for ts_name in ts_map]
             labels = {label: label_value, b"__reducer__": reducer, b"__source__": sources}
-            measurements: List[List[Union[int, float]]] = [
+            measurements: list[list[int | float]] = [
                 [timestamp, float(AGGREGATORS[reducer](timestamp_values[timestamp]))] for timestamp in sorted_timestamps
             ]
             if reverse:
@@ -504,7 +504,6 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
             b"filter_by_value",
             b"filter_by_ts",
             b"align",
-            b"aggregation",
         }
         left_args = []
         latest, with_labels, selected_labels, filter_expression, group_by, reducer = (
@@ -580,13 +579,9 @@ class TimeSeriesCommandsMixin(CommandsMixinBase):  # TimeSeries commands
         return res
 
     @command(name="TS.MRANGE", fixed=(Timestamp, Timestamp), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def ts_mrange(
-        self, from_ts: int, to_ts: int, *args: bytes
-    ) -> List[List[Union[bytes, List[List[Union[int, float]]]]]]:
+    def ts_mrange(self, from_ts: int, to_ts: int, *args: bytes) -> list[list[bytes | list[list[int | float]]]]:
         return self._mrange(False, from_ts, to_ts, *args)  # type: ignore[no-any-return]
 
     @command(name="TS.MREVRANGE", fixed=(Timestamp, Timestamp), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def ts_mrevrange(
-        self, from_ts: int, to_ts: int, *args: bytes
-    ) -> List[List[Union[bytes, List[List[Union[int, float]]]]]]:
+    def ts_mrevrange(self, from_ts: int, to_ts: int, *args: bytes) -> list[list[bytes | list[list[int | float]]]]:
         return self._mrange(True, from_ts, to_ts, *args)  # type: ignore[no-any-return]

--- a/fakeredis/stack/_topk_mixin.py
+++ b/fakeredis/stack/_topk_mixin.py
@@ -1,8 +1,10 @@
-from typing import Any, List, Optional, Tuple, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
-from fakeredis._commands import Key, Int, Float, command, CommandItem
+from fakeredis._commands import CommandItem, Float, Int, Key, command
 from fakeredis._helpers import OK, SimpleError, SimpleString
 from fakeredis.model import HeavyKeeper
 
@@ -14,7 +16,7 @@ class TopkCommandsMixin:
         super().__init__(*args, **kwargs)
 
     @command(name="TOPK.ADD", fixed=(Key(HeavyKeeper), bytes), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def topk_add(self, key: CommandItem, *args: bytes) -> List[Optional[bytes]]:
+    def topk_add(self, key: CommandItem, *args: bytes) -> list[bytes | None]:
         if key.value is None:
             raise SimpleError("TopK: key does not exist")
         if not isinstance(key.value, HeavyKeeper):
@@ -24,26 +26,26 @@ class TopkCommandsMixin:
         return res
 
     @command(name="TOPK.COUNT", fixed=(Key(HeavyKeeper), bytes), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def topk_count(self, key: CommandItem, *args: bytes) -> List[int]:
+    def topk_count(self, key: CommandItem, *args: bytes) -> list[int]:
         if key.value is None:
             raise SimpleError("TopK: key does not exist")
         if not isinstance(key.value, HeavyKeeper):
             raise SimpleError("TOPK: key is not a HeavyKeeper")
-        res: List[int] = [key.value.count(_item) for _item in args]
+        res: list[int] = [key.value.count(_item) for _item in args]
         return res
 
     @command(name="TOPK.QUERY", fixed=(Key(HeavyKeeper), bytes), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def topk_query(self, key: CommandItem, *args: bytes) -> List[int]:
+    def topk_query(self, key: CommandItem, *args: bytes) -> list[int]:
         if key.value is None:
             raise SimpleError("TopK: key does not exist")
         if not isinstance(key.value, HeavyKeeper):
             raise SimpleError("TOPK: key is not a HeavyKeeper")
         topk = {item[1] for item in key.value.list()}
-        res: List[int] = [1 if _item in topk else 0 for _item in args]
+        res: list[int] = [1 if _item in topk else 0 for _item in args]
         return res
 
     @command(name="TOPK.INCRBY", fixed=(Key(), bytes, Int), repeat=(bytes, Int), flags=msgs.FLAG_DO_NOT_CREATE)
-    def topk_incrby(self, key: CommandItem, *args: Any) -> List[Optional[bytes]]:
+    def topk_incrby(self, key: CommandItem, *args: Any) -> list[bytes | None]:
         if key.value is None:
             raise SimpleError("TopK: key does not exist")
         if not isinstance(key.value, HeavyKeeper):
@@ -58,7 +60,7 @@ class TopkCommandsMixin:
         return res
 
     @command(name="TOPK.INFO", fixed=(Key(),), repeat=(), flags=msgs.FLAG_DO_NOT_CREATE)
-    def topk_info(self, key: CommandItem) -> Dict[bytes, Any]:
+    def topk_info(self, key: CommandItem) -> dict[bytes, Any]:
         if key.value is None:
             raise SimpleError("TopK: key does not exist")
         if not isinstance(key.value, HeavyKeeper):
@@ -71,13 +73,13 @@ class TopkCommandsMixin:
         }
 
     @command(name="TOPK.LIST", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def topk_list(self, key: CommandItem, *args: Any) -> List[Any]:
+    def topk_list(self, key: CommandItem, *args: Any) -> list[Any]:
         (withcount,), _ = extract_args(args, ("withcount",))
         if key.value is None:
             raise SimpleError("TopK: key does not exist")
         if not isinstance(key.value, HeavyKeeper):
             raise SimpleError("TOPK: key is not a HeavyKeeper")
-        value_list: List[Tuple[int, bytes]] = key.value.list()
+        value_list: list[tuple[int, bytes]] = key.value.list()
         if not withcount:
             return [item[1] for item in value_list]
         else:

--- a/fakeredis/stack/_vectorset_mixin.py
+++ b/fakeredis/stack/_vectorset_mixin.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import itertools
 import random
 import struct
-from typing import Any, List, Literal, Optional, Union, cast
+from typing import Any, Literal, cast
 
 from fakeredis import _msgs as msgs
-from fakeredis._commands import Key, command, CommandItem, StringTest
+from fakeredis._commands import CommandItem, Key, StringTest, command
 from fakeredis._helpers import SimpleError, casematch
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
-from fakeredis.model import VectorSet, Vector
+from fakeredis.model import Vector, VectorSet
 
 VSET_ERR_NOTEXIST = "ERR key does not exist"
 
@@ -19,7 +21,7 @@ class VectorSetCommandsMixin(CommandsMixinBase):
         super().__init__(*args, **kwargs)
 
     @command(name="VCARD", fixed=(Key(VectorSet),), flags=msgs.FLAG_DO_NOT_CREATE)
-    def vcard(self, key: CommandItem) -> Optional[int]:
+    def vcard(self, key: CommandItem) -> int | None:
         if key.value is None:
             return 0
         vs: VectorSet = key.value
@@ -33,7 +35,7 @@ class VectorSetCommandsMixin(CommandsMixinBase):
         return vs.dimensions
 
     @command(name="VGETATTR", fixed=(Key(VectorSet), bytes), flags=msgs.FLAG_DO_NOT_CREATE)
-    def vgetattr(self, key: CommandItem, member: bytes) -> Optional[bytes]:
+    def vgetattr(self, key: CommandItem, member: bytes) -> bytes | None:
         if key.value is None:
             return None
         vs: VectorSet = key.value
@@ -119,7 +121,7 @@ class VectorSetCommandsMixin(CommandsMixinBase):
         return 1
 
     @command(name="VEMB", fixed=(Key(VectorSet), bytes), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def vemb(self, key: CommandItem, element: bytes, *args: bytes) -> Optional[List[float]]:
+    def vemb(self, key: CommandItem, element: bytes, *args: bytes) -> list[float] | None:
         if key.value is None:
             return None
         if element not in key.value:
@@ -138,7 +140,7 @@ class VectorSetCommandsMixin(CommandsMixinBase):
         return vector.values
 
     @command(name="VRANDMEMBER", fixed=(Key(VectorSet),), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
-    def vrandmember(self, key: CommandItem, *args: bytes) -> Optional[Union[bytes, List[bytes]]]:
+    def vrandmember(self, key: CommandItem, *args: bytes) -> bytes | list[bytes] | None:
         if key.value is None:
             return None if len(args) == 0 else []
         try:
@@ -173,7 +175,7 @@ class VectorSetCommandsMixin(CommandsMixinBase):
         repeat=(bytes,),
         flags=msgs.FLAG_DO_NOT_CREATE,
     )
-    def vrange(self, key: CommandItem, _min: StringTest, _max: StringTest, *args: bytes) -> List[bytes]:
+    def vrange(self, key: CommandItem, _min: StringTest, _max: StringTest, *args: bytes) -> list[bytes]:
         if len(args) > 1:
             raise SimpleError(msgs.WRONG_ARGS_MSG6.format("VRANGE"))
         if key.value is None:
@@ -199,9 +201,9 @@ class VectorSetCommandsMixin(CommandsMixinBase):
         if key.value is None:
             return []
         vector_set: VectorSet = key.value
-        vector: Optional[Vector] = None  # The vector to compare against.
+        vector: Vector | None = None  # The vector to compare against.
         with_scores, with_attributes, count, epsilon, filter_expression = False, False, 10, None, None
-        filter_ef: Optional[int] = None
+        filter_ef: int | None = None
         i = 0
         while i < len(args):
             if casematch(args[i], b"ele") and i + 1 < len(args):
@@ -249,9 +251,7 @@ class VectorSetCommandsMixin(CommandsMixinBase):
             elif casematch(args[i], b"filter-ef") and i + 1 < len(args):
                 filter_ef = int(args[i + 1])
                 i += 2
-            elif casematch(args[i], b"truth"):
-                i += 1
-            elif casematch(args[i], b"nothread"):
+            elif casematch(args[i], b"truth") or casematch(args[i], b"nothread"):
                 i += 1
             else:
                 raise SimpleError(msgs.SYNTAX_ERROR_MSG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -138,7 +139,7 @@ exclude = [".venv", "test", "__pycache__"]
 [tool.ruff]
 line-length = 120
 exclude = ['.venv', '__pycache__']
-target-version = "py39"
+target-version = "py38"
 
 [tool.ruff.format]
 quote-style = "double"
@@ -155,6 +156,13 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"test/**" = ["DTZ005", "DTZ006"]                            # tests use naive local datetimes for expiry/time checks on purpose
-"test/test_mixins/test_connection_commands.py" = ["B017"]  # broad pytest.raises across redis + valkey disconnected clients
-"test/test_stack/test_json.py" = ["SIM115"]                # NamedTemporaryFile handles kept open across the test on purpose
+"test/**" = [
+  "DTZ005",
+  "DTZ006",
+] # tests use naive local datetimes for expiry/time checks on purpose
+"test/test_mixins/test_connection_commands.py" = [
+  "B017",
+] # broad pytest.raises across redis + valkey disconnected clients
+"test/test_stack/test_json.py" = [
+  "SIM115",
+] # NamedTemporaryFile handles kept open across the test on purpose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,3 +145,16 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.ruff.lint]
+# The project uses Ruff's default rule set. A few opinionated rules are disabled
+# where the flagged pattern is deliberate.
+ignore = [
+  "BLE001", # blind-except: intentional broad `except Exception` for robustness (pub/sub delivery, stream parsing, harnesses)
+  "S112",   # try-except-continue: intentional skipping of malformed stream entries
+]
+
+[tool.ruff.lint.per-file-ignores]
+"test/**" = ["DTZ005", "DTZ006"]                            # tests use naive local datetimes for expiry/time checks on purpose
+"test/test_mixins/test_connection_commands.py" = ["B017"]  # broad pytest.raises across redis + valkey disconnected clients
+"test/test_stack/test_json.py" = ["SIM115"]                # NamedTemporaryFile handles kept open across the test on purpose

--- a/scripts/generate_command_info.py
+++ b/scripts/generate_command_info.py
@@ -19,7 +19,7 @@ that is used for the `COMMAND` redis command.
 
 import json
 import os
-from typing import Any, Dict, List
+from typing import Any
 
 from fakeredis._commands import SUPPORTED_COMMANDS
 from scripts.generate_supported_commands_doc import METADATA, download_single_stack_commands
@@ -47,7 +47,7 @@ def implemented_commands() -> set:
     return res
 
 
-def dict_deep_get(d: Dict[Any, Any], *keys, default_value: Any = None) -> Any:
+def dict_deep_get(d: dict[Any, Any], *keys, default_value: Any = None) -> Any:
     res = d
     for key in keys:
         if isinstance(res, list) and isinstance(key, int):
@@ -59,11 +59,11 @@ def dict_deep_get(d: Dict[Any, Any], *keys, default_value: Any = None) -> Any:
     return default_value if res is None else res
 
 
-def key_specs_array(cmd_info: Dict[str, Any]) -> List[Any]:
+def key_specs_array(cmd_info: dict[str, Any]) -> list[Any]:
     return []
 
 
-def get_command_info(cmd_name: str, all_commands: Dict[str, Any]) -> List[Any]:
+def get_command_info(cmd_name: str, all_commands: dict[str, Any]) -> list[Any]:
     """Returns a list
      1 Name //
      2 Arity //
@@ -106,7 +106,7 @@ def get_command_info(cmd_name: str, all_commands: Dict[str, Any]) -> List[Any]:
 
 if __name__ == "__main__":
     implemented = implemented_commands()
-    command_info_dict: Dict[str, List[Any]] = {}
+    command_info_dict: dict[str, list[Any]] = {}
     for cmd_meta in METADATA:
         cmds = download_single_stack_commands(cmd_meta.local_filename, cmd_meta.url, cmd_meta.markdown_commands)
         for cmd in cmds:

--- a/scripts/generate_command_info.py
+++ b/scripts/generate_command_info.py
@@ -17,6 +17,8 @@ Generates a JSON file with the following structure:
 that is used for the `COMMAND` redis command.
 """
 
+from __future__ import annotations
+
 import json
 import os
 from typing import Any

--- a/scripts/generate_supported_commands_doc.py
+++ b/scripts/generate_supported_commands_doc.py
@@ -2,6 +2,8 @@
 This script generates the markdown files for the supported commands documentation.
 """
 
+from __future__ import annotations
+
 import json
 import os
 from dataclasses import dataclass

--- a/scripts/generate_supported_commands_doc.py
+++ b/scripts/generate_supported_commands_doc.py
@@ -96,13 +96,14 @@ def download_command_markdown(command: str) -> dict:
     filename = os.path.join(THIS_DIR, f"{command}.md")
     if not os.path.exists(filename):
         contents = requests.get(url).content
-        open(filename, "wb").write(contents)
+        with open(filename, "wb") as f:
+            f.write(contents)
     # Read markdown file and extract metadata from the top of the file, which is in the format:
     # ---
     # summary: "summary of the command"
     # group: "group of the command"
     # ---
-    with open(filename, "r") as f:
+    with open(filename) as f:
         lines = f.readlines()
     metadata = {}
     if lines[0].strip() == "---":
@@ -117,8 +118,10 @@ def download_single_stack_commands(filename, url, markdown_commands: list[str]) 
     full_filename = os.path.join(THIS_DIR, filename)
     if not os.path.exists(full_filename):
         contents = requests.get(url).content
-        open(full_filename, "wb").write(contents)
-    curr_cmds = json.load(open(full_filename))
+        with open(full_filename, "wb") as f:
+            f.write(contents)
+    with open(full_filename) as f:
+        curr_cmds = json.load(f)
     cmds = {k.lower(): v for k, v in curr_cmds.items()}
     for cmd in markdown_commands:
         if cmd.lower() not in cmds:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import time
+from collections.abc import Generator
 from dataclasses import dataclass
 from threading import Thread
-from typing import Any, Callable, Dict, Generator, Optional, Tuple, Type, Union
+from typing import Any, Callable
 
 import pytest
 import pytest_asyncio
@@ -19,8 +22,8 @@ from test.testtools import REDIS_PY_VERSION
 class ServerDetails:
     server_type: ServerType
     redis_version: VersionType
-    valkey_version: Optional[VersionType]
-    dragonfly_version: Optional[VersionType]
+    valkey_version: VersionType | None
+    dragonfly_version: VersionType | None
 
     @property
     def server_version(self) -> VersionType:
@@ -41,13 +44,13 @@ def _check_lua_module_supported() -> bool:
 
 
 @pytest.fixture(scope="session")
-def real_server_address() -> Tuple[str, int]:
+def real_server_address() -> tuple[str, int]:
     """Returns real server address"""
     return "localhost", 6390
 
 
 @pytest.fixture(scope="session")
-def real_server_details(real_server_address: Tuple[str, int]) -> ServerDetails:
+def real_server_details(real_server_address: tuple[str, int]) -> ServerDetails:
     """Returns server's version or exit if server is not running"""
     client = None
     try:
@@ -140,7 +143,7 @@ def _validate_server_versions(request, real_server_details: ServerDetails) -> No
 
 
 # Map from (server_type is valkey, fake flag, async flag) -> client class
-CLIENT_CLASS_MAP: Dict[Tuple[bool, bool, bool], Union[Type[ClientType], Type[AsyncClientType]]] = {
+CLIENT_CLASS_MAP: dict[tuple[bool, bool, bool], type[ClientType | AsyncClientType]] = {
     (True, True, False): fakeredis.FakeValkey,
     (True, False, False): valkey.StrictValkey,
     (False, True, False): fakeredis.FakeStrictRedis,
@@ -154,7 +157,7 @@ CLIENT_CLASS_MAP: Dict[Tuple[bool, bool, bool], Union[Type[ClientType], Type[Asy
 
 def _get_class(
     cls_type: str, real_server_details: ServerDetails, async_client: bool
-) -> Union[Type[ClientType], Type[AsyncClientType]]:
+) -> type[ClientType | AsyncClientType]:
     is_valkey = real_server_details.server_type == "valkey"
     is_fake = cls_type.lower().startswith("fake")
     res = CLIENT_CLASS_MAP[is_valkey, is_fake, async_client]
@@ -170,7 +173,7 @@ def _get_class(
         pytest.param("FakeStrict3", marks=pytest.mark.fake),
     ],
 )
-def _create_connection(request, real_server_details: ServerDetails) -> Callable[[Dict[str, Any]], ClientType]:
+def _create_connection(request, real_server_details: ServerDetails) -> Callable[[dict[str, Any]], ClientType]:
     cls_type, protocol = request.param[:-1], int(request.param[-1])
     if request.node.get_closest_marker("fake_only") and not cls_type.startswith("Fake"):
         pytest.skip("Test is only applicable to fakeredis")
@@ -230,13 +233,13 @@ async def _req_aioredis2(request, real_server_details: ServerDetails) -> AsyncCl
     lua_modules = set(lua_modules_marker.args) if lua_modules_marker else None
     if lua_modules and not _check_lua_module_supported():
         pytest.skip("LUA modules not supported by fakeredis")
-    fake_server: Optional[fakeredis.FakeServer]
+    fake_server: fakeredis.FakeServer | None
     cls = _get_class(param_type, real_server_details, True)
     if param_type == "fake":
         fake_server = request.getfixturevalue("fake_server")
         ret = cls(server=fake_server, lua_modules=lua_modules, decode_responses=decode_responses, protocol=protocol)
     else:
-        kwds = dict(host="localhost", port=6390, db=2, decode_responses=decode_responses)
+        kwds = {"host": "localhost", "port": 6390, "db": 2, "decode_responses": decode_responses}
         if REDIS_PY_VERSION.major >= 5:
             kwds["protocol"] = protocol
         ret = cls(**kwds)

--- a/test/test_async/test_asyncredis.py
+++ b/test/test_async/test_asyncredis.py
@@ -11,7 +11,7 @@ import valkey
 
 import fakeredis
 from fakeredis import FakeServer, aioredis
-from fakeredis._typing import async_timeout, AsyncClientType
+from fakeredis._typing import AsyncClientType, async_timeout
 from test import testtools
 from test.testtools import resp_conversion
 
@@ -201,12 +201,12 @@ async def test_type(async_redis: AsyncClientType):
     await async_redis.zadd("zset_key", {"value": 1})
     await async_redis.hset("hset_key", "key", "value")
 
-    assert b"string" == await async_redis.type("string_key")  # noqa: E721
-    assert b"list" == await async_redis.type("list_key")  # noqa: E721
-    assert b"set" == await async_redis.type("set_key")  # noqa: E721
-    assert b"zset" == await async_redis.type("zset_key")  # noqa: E721
-    assert b"hash" == await async_redis.type("hset_key")  # noqa: E721
-    assert b"none" == await async_redis.type("none_key")  # noqa: E721
+    assert b"string" == await async_redis.type("string_key")
+    assert b"list" == await async_redis.type("list_key")
+    assert b"set" == await async_redis.type("set_key")
+    assert b"zset" == await async_redis.type("zset_key")
+    assert b"hash" == await async_redis.type("hset_key")
+    assert b"none" == await async_redis.type("none_key")
 
 
 async def test_xdel(async_redis: AsyncClientType):

--- a/test/test_hypothesis/base.py
+++ b/test/test_hypothesis/base.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import functools
 import math
 import operator
 import string
 import sys
 from dataclasses import dataclass
-from typing import Any, Tuple, Optional
+from typing import Any
 
 import hypothesis.strategies as st
 import pytest
@@ -43,7 +45,7 @@ class MachineConfig:
     """Everything a state machine needs to talk to both servers."""
 
     server_type: str
-    version: Tuple[int, ...]
+    version: tuple[int, ...]
     host: str = "localhost"
     port: int = 6390
     db: int = 2
@@ -58,10 +60,10 @@ class MachineConfig:
         return cls(server=server, db=self.db)
 
 
-_active_config: Optional[MachineConfig] = None
+_active_config: MachineConfig | None = None
 
 
-def _server_version() -> Tuple[int, ...]:
+def _server_version() -> tuple[int, ...]:
     return _active_config.version if _active_config is not None else (7,)
 
 
@@ -118,7 +120,7 @@ class WrappedException:
         return str(self.wrapped)
 
     def __repr__(self):
-        return "WrappedException({!r})".format(self.wrapped)
+        return f"WrappedException({self.wrapped!r})"
 
     def __eq__(self, other):
         if not isinstance(other, WrappedException):
@@ -227,9 +229,7 @@ class Command:
         # Redis will ignore a NULL character in some commands but not others,
         # e.g., it recognizes EXEC\0 but not MULTI\00.
         # Rather than try to reproduce this quirky behavior, just skip these tests.
-        if b"\0" in command:
-            return False
-        return True
+        return b"\x00" not in command
 
 
 def commands(*args, **kwargs):

--- a/test/test_hypothesis/conftest.py
+++ b/test/test_hypothesis/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 import pytest
 import redis
@@ -19,7 +19,7 @@ settings.load_profile("fakeredis")
 
 
 @pytest.fixture
-def hypothesis_config(real_server_details: ServerDetails, real_server_address: Tuple[str, int]) -> MachineConfig:
+def hypothesis_config(real_server_details: ServerDetails, real_server_address: tuple[str, int]) -> MachineConfig:
     """Server details for a differential Hypothesis machine.
 
     Reuses the session-scoped ``real_server_details``/``real_server_address``

--- a/test/test_internals/test_acl_save_load.py
+++ b/test/test_internals/test_acl_save_load.py
@@ -22,7 +22,7 @@ def test_acl_save_load():
     r.acl_save()
 
     # assert acl file contains all data
-    with open(acl_filename, "r") as f:
+    with open(acl_filename) as f:
         lines = f.readlines()
         assert len(lines) == 2
         user_rule = lines[1]

--- a/test/test_internals/test_async_connection.py
+++ b/test/test_internals/test_async_connection.py
@@ -3,7 +3,7 @@ import redis
 import redis.asyncio
 import valkey
 
-from fakeredis import FakeServer, aioredis, FakeAsyncRedis, FakeStrictRedis
+from fakeredis import FakeAsyncRedis, FakeServer, FakeStrictRedis, aioredis
 from fakeredis._typing import AsyncClientType
 from test import testtools
 

--- a/test/test_internals/test_extract_args.py
+++ b/test/test_internals/test_extract_args.py
@@ -102,7 +102,7 @@ def test_extract_args__extract_non_numbers():
 
 def test_extract_args__extract_maxlen():
     args = (b"MAXLEN", b"5")
-    (nomkstream, limit, maxlen, maxid), left_args = extract_args(
+    (nomkstream, limit, maxlen, maxid), _left_args = extract_args(
         args, ("nomkstream", "+limit", "~+maxlen", "~maxid"), error_on_unexpected=False
     )
     assert not nomkstream
@@ -111,7 +111,7 @@ def test_extract_args__extract_maxlen():
     assert maxid is None
 
     args = (b"MAXLEN", b"~", b"5", b"maxid", b"~", b"1")
-    (nomkstream, limit, maxlen, maxid), left_args = extract_args(
+    (nomkstream, limit, maxlen, maxid), _left_args = extract_args(
         args, ("nomkstream", "+limit", "~+maxlen", "~maxid"), error_on_unexpected=False
     )
     assert not nomkstream

--- a/test/test_internals/test_xstream.py
+++ b/test/test_internals/test_xstream.py
@@ -1,6 +1,6 @@
 import pytest
 
-from fakeredis.model import XStream, StreamRangeTest
+from fakeredis.model import StreamRangeTest, XStream
 
 
 @pytest.mark.fake

--- a/test/test_mixins/test_bitmap_commands.py
+++ b/test/test_mixins/test_bitmap_commands.py
@@ -267,13 +267,13 @@ def test_bitfield_wrong_arguments(r: ClientType):
 def test_bitfield_get(r: ClientType):
     key = "key:bitfield_get"
     r.set(key, b"\xff\xf0\x00")
-    for i in range(0, 12):
+    for i in range(12):
         assert r.bitfield(key).get("u1", i).get("i1", i).execute() == [1, -1]
     for i in range(12, 25):
         for j in range(1, 63):
             assert r.bitfield(key).get(f"u{j}", i).get(f"i{j}", i).execute() == [0, 0]
 
-    for i in range(0, 11):
+    for i in range(11):
         assert r.bitfield(key).get("u2", i).get("i2", i).execute() == [3, -1]
     assert r.bitfield(key).get("u2", 11).get("i2", 11).execute() == [2, -2]
     assert r.bitfield(key).get("u8", 0).get("u8", 8).get("u8", 16).execute() == [0xFF, 0xF0, 0]

--- a/test/test_mixins/test_connection_commands.py
+++ b/test/test_mixins/test_connection_commands.py
@@ -331,7 +331,7 @@ def _block_on_blpop(client: ClientType, result: dict) -> threading.Thread:
     def target() -> None:
         try:
             result["value"] = client.blpop("unblock-list", timeout=5)
-        except Exception as e:  # noqa: BLE001 - recorded so the assertion can describe it
+        except Exception as e:
             result["error"] = e
 
     thread = threading.Thread(target=target)
@@ -876,9 +876,8 @@ class TestFakeStrictRedisConnectionErrors:
             r.transaction(func, 3)
 
     def test_lock(self, r):
-        with pytest.raises(Exception):
-            with r.lock("name"):
-                pass
+        with pytest.raises(Exception), r.lock("name"):
+            pass
 
     def test_pubsub(self, r):
         with pytest.raises(Exception):

--- a/test/test_mixins/test_generic_commands.py
+++ b/test/test_mixins/test_generic_commands.py
@@ -279,12 +279,12 @@ def test_type(r: ClientType):
     r.zadd("zset_key", {"value": 1})
     r.hset("hset_key", "key", "value")
 
-    assert r.type("string_key") == b"string"  # noqa: E721
-    assert r.type("list_key") == b"list"  # noqa: E721
-    assert r.type("set_key") == b"set"  # noqa: E721
-    assert r.type("zset_key") == b"zset"  # noqa: E721
-    assert r.type("hset_key") == b"hash"  # noqa: E721
-    assert r.type("none_key") == b"none"  # noqa: E721
+    assert r.type("string_key") == b"string"
+    assert r.type("list_key") == b"list"
+    assert r.type("set_key") == b"set"
+    assert r.type("zset_key") == b"zset"
+    assert r.type("hset_key") == b"hash"
+    assert r.type("none_key") == b"none"
 
 
 def test_unlink(r: ClientType):

--- a/test/test_mixins/test_generic_scan_commands.py
+++ b/test/test_mixins/test_generic_scan_commands.py
@@ -109,8 +109,8 @@ def test_scan_add_key_while_scanning_should_return_all_keys(r: ClientType):
 def test_scan(r: ClientType):
     # Set up the data
     for ix in range(20):
-        k = "scan-test:%s" % ix
-        v = "result:%s" % ix
+        k = f"scan-test:{ix}"
+        v = f"result:{ix}"
         r.set(k, v)
     expected = r.keys()
     assert len(expected) == 20  # Ensure we know what we're testing

--- a/test/test_mixins/test_geo_commands.py
+++ b/test/test_mixins/test_geo_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 import pytest

--- a/test/test_mixins/test_geo_commands.py
+++ b/test/test_mixins/test_geo_commands.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 import pytest
 import redis
@@ -112,7 +112,7 @@ def test_geodist_missing_one_member(r: ClientType):
         (2.191, 41.433, 3000, {"count": 1}, [b"place1"]),
     ],
 )
-def test_georadius(r: ClientType, long: float, lat: float, radius: float, extra: Dict[str, Any], expected):
+def test_georadius(r: ClientType, long: float, lat: float, radius: float, extra: dict[str, Any], expected):
     values = (2.1909389952632, 41.433791470673, "place1", 2.1873744593677, 41.406342043777, "place2")
     r.geoadd("barcelona", values)
     assert r.georadius("barcelona", long, lat, radius, **extra) == expected
@@ -128,7 +128,7 @@ def test_georadius(r: ClientType, long: float, lat: float, radius: float, extra:
         ("place1", 3000, {"count": 1}, [b"place1"]),
     ],
 )
-def test_georadiusbymember(r: ClientType, member: str, radius: float, extra: Dict[str, Any], expected):
+def test_georadiusbymember(r: ClientType, member: str, radius: float, extra: dict[str, Any], expected):
     values = (2.1909389952632, 41.433791470673, "place1", 2.1873744593677, 41.406342043777, b"place2")
     r.geoadd("barcelona", values)
     assert r.georadiusbymember("barcelona", member, radius, **extra) == expected

--- a/test/test_mixins/test_hash_commands.py
+++ b/test/test_mixins/test_hash_commands.py
@@ -286,8 +286,8 @@ def test_hset_removing_last_field_delete_key(r: ClientType):
 def test_hscan_no_values(r: ClientType):
     name = "hscan-test"
     for ix in range(20):
-        k = "key:%s" % ix
-        v = "result:%s" % ix
+        k = f"key:{ix}"
+        v = f"result:{ix}"
         r.hset(name, k, v)
     expected = r.hgetall(name)
     assert len(expected) == 20  # Ensure we know what we're testing
@@ -305,8 +305,8 @@ def test_hscan(r: ClientType):
     # Set up the data
     name = "hscan-test"
     for ix in range(20):
-        k = "key:%s" % ix
-        v = "result:%s" % ix
+        k = f"key:{ix}"
+        v = f"result:{ix}"
         r.hset(name, k, v)
     expected = r.hgetall(name)
     assert len(expected) == 20  # Ensure we know what we're testing

--- a/test/test_mixins/test_hash_expire_commands.py
+++ b/test/test_mixins/test_hash_expire_commands.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import time
-from typing import Optional, Dict
 
 import pytest
 
@@ -43,8 +44,8 @@ pytestmark.extend(
 def test_hexpire(
     r: ClientType,
     expiration_seconds: int,
-    preset_expiration: Optional[int],
-    flags: Dict[str, bool],
+    preset_expiration: int | None,
+    flags: dict[str, bool],
     expected_result: int,
 ) -> None:
     key, field = "redis-key", "hash-key"

--- a/test/test_mixins/test_list_commands.py
+++ b/test/test_mixins/test_list_commands.py
@@ -6,6 +6,7 @@ import redis
 import valkey
 
 from fakeredis._typing import ClientType
+
 from .. import testtools
 from ..testtools import resp_conversion
 

--- a/test/test_mixins/test_pubsub_commands.py
+++ b/test/test_mixins/test_pubsub_commands.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import threading
 import time
 import uuid
 from queue import Queue
 from time import sleep
-from typing import Optional, Dict, Any
+from typing import Any
 
 import pytest
 import redis
@@ -12,11 +14,12 @@ from redis.client import PubSub
 
 import fakeredis
 from fakeredis._typing import ClientType
+
 from .. import testtools
 from ..testtools import resp_conversion
 
 
-def wait_for_message(pubsub: PubSub, timeout=0.5, ignore_subscribe_messages=False) -> Optional[Dict[str, Any]]:
+def wait_for_message(pubsub: PubSub, timeout=0.5, ignore_subscribe_messages=False) -> dict[str, Any] | None:
     now = time.time()
     timeout = now + timeout
     while now < timeout:
@@ -144,10 +147,8 @@ def test_pubsub_punsubscribe(r: ClientType):
 @pytest.mark.slow
 def test_pubsub_listen(r: ClientType):
     def _listen(pubsub, q):
-        count = 0
-        for message in pubsub.listen():
+        for count, message in enumerate(pubsub.listen(), start=1):
             q.put(message)
-            count += 1
             if count == 4:
                 pubsub.close()
 
@@ -213,10 +214,8 @@ def test_pubsub_listen_handler(r: ClientType):
 @pytest.mark.slow
 def test_pubsub_ignore_sub_messages_listen(r: ClientType):
     def _listen(pubsub, q):
-        count = 0
-        for message in pubsub.listen():
+        for count, message in enumerate(pubsub.listen(), start=1):
             q.put(message)
-            count += 1
             if count == 4:
                 pubsub.close()
 

--- a/test/test_mixins/test_scripting_commands.py
+++ b/test/test_mixins/test_scripting_commands.py
@@ -41,13 +41,13 @@ def test_script_exists_redis7(r: ClientType):
 @pytest.mark.parametrize("args", [("a",), tuple("abcdefghijklmn")])
 def test_script_flush_errors_with_args(r, args):
     with pytest.raises(Exception) as ctx:
-        raw_command(r, "SCRIPT FLUSH %s" % " ".join(args))
+        raw_command(r, "SCRIPT FLUSH {}".format(" ".join(args)))
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
 def test_script_flush(r: ClientType):
     # generate/load six unique scripts and store their sha1 hash values
-    sha1_values = [r.script_load("return '%s'" % char) for char in "abcdef"]
+    sha1_values = [r.script_load(f"return '{char}'") for char in "abcdef"]
 
     # assert the scripts all exist prior to flushing
     assert r.script_exists(*sha1_values) == [1] * len(sha1_values)

--- a/test/test_mixins/test_set_commands.py
+++ b/test/test_mixins/test_set_commands.py
@@ -354,7 +354,7 @@ def test_sscan(r: ClientType):
     # Set up the data
     name = "sscan-test"
     for ix in range(20):
-        k = "sscan-test:%s" % ix
+        k = f"sscan-test:{ix}"
         r.sadd(name, k)
     expected = r.smembers(name)
     assert len(expected) == 20  # Ensure we know what we're testing

--- a/test/test_mixins/test_sortedset_commands.py
+++ b/test/test_mixins/test_sortedset_commands.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from collections import OrderedDict
-from typing import Tuple, List, Optional
-
 import math
+from collections import OrderedDict
+
 import pytest
 import redis
 import valkey
@@ -334,11 +333,11 @@ def test_zmscore(r: ClientType):
     The order of the returned scores should always match the order in which the set members were supplied.
     """
     cache_key: str = "scored-set-members"
-    members: Tuple[str, ...] = ("one", "two", "three", "four", "five", "six")
-    scores: Tuple[float, ...] = (1.1, 2.2, 3.3, 4.4, 5.5, 6.6)
+    members: tuple[str, ...] = ("one", "two", "three", "four", "five", "six")
+    scores: tuple[float, ...] = (1.1, 2.2, 3.3, 4.4, 5.5, 6.6)
 
     r.zadd(cache_key, dict(zip(members, scores)))
-    cached_scores: List[Optional[float]] = r.zmscore(
+    cached_scores: list[float | None] = r.zmscore(
         cache_key,
         list(members),
     )
@@ -350,10 +349,10 @@ def test_zmscore_missing_members(r: ClientType):
     """When none of the requested sorted-set members are in the cache, a value
     of `None` should be returned once for each requested member."""
     cache_key: str = "scored-set-members"
-    members: Tuple[str, ...] = ("one", "two", "three", "four", "five", "six")
+    members: tuple[str, ...] = ("one", "two", "three", "four", "five", "six")
 
     r.zadd(cache_key, {"eight": 8.8})
-    cached_scores: List[Optional[float]] = r.zmscore(
+    cached_scores: list[float | None] = r.zmscore(
         cache_key,
         list(members),
     )
@@ -370,15 +369,15 @@ def test_zmscore_mixed_membership(r: ClientType):
     which the set members were supplied.
     """
     cache_key: str = "scored-set-members"
-    members: Tuple[str, ...] = ("one", "two", "three", "four", "five", "six")
-    scores: Tuple[float, ...] = (1.1, 2.2, 3.3, 4.4, 5.5, 6.6)
+    members: tuple[str, ...] = ("one", "two", "three", "four", "five", "six")
+    scores: tuple[float, ...] = (1.1, 2.2, 3.3, 4.4, 5.5, 6.6)
 
     r.zadd(
         cache_key,
         {member: scores[idx] for (idx, member) in enumerate(members) if idx % 2 != 0},
     )
 
-    cached_scores: List[Optional[float]] = r.zmscore(cache_key, list(members))
+    cached_scores: list[float | None] = r.zmscore(cache_key, list(members))
 
     assert all(cached_scores[idx] is None for (idx, score) in enumerate(scores) if idx % 2 == 0)
     assert all(cached_scores[idx] == score for (idx, score) in enumerate(scores) if idx % 2 != 0)
@@ -1139,7 +1138,7 @@ def test_zscan(r: ClientType):
     # Set up the data
     name = "zscan-test"
     for ix in range(20):
-        r.zadd(name, {"key:%s" % ix: ix})
+        r.zadd(name, {f"key:{ix}": ix})
     expected = dict(r.zrange(name, 0, -1, withscores=True))
 
     # Test the basic version

--- a/test/test_mixins/test_sortedset_zadd.py
+++ b/test/test_mixins/test_sortedset_zadd.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import redis
 import valkey

--- a/test/test_mixins/test_sortedset_zadd.py
+++ b/test/test_mixins/test_sortedset_zadd.py
@@ -1,5 +1,3 @@
-from typing import Tuple, List, Dict
-
 import pytest
 import redis
 import valkey
@@ -69,9 +67,9 @@ def test_zadd_multiple(r: ClientType):
 @pytest.mark.parametrize("ch", [False, True])
 def test_zadd_with_nx(
     r: ClientType,
-    map_to_add: Dict[str, float],
+    map_to_add: dict[str, float],
     expected_ret: int,
-    expected_zrange_state: List[Tuple[bytes, float]],
+    expected_zrange_state: list[tuple[bytes, float]],
     ch: bool,
 ):
     r.zadd("foo", {"four": 4.0, "three": 3.0})
@@ -99,7 +97,7 @@ def test_zadd_with_nx(
     ids=["no_additions", "partial_additions", "new_additions"],
 )
 def test_zadd_with_gt_and_ch(
-    r: ClientType, map_to_add: Dict[str, float], expected_ret: int, expected_zrange_state: List[Tuple[bytes, float]]
+    r: ClientType, map_to_add: dict[str, float], expected_ret: int, expected_zrange_state: list[tuple[bytes, float]]
 ):
     r.zadd("foo", {"four": 4.0, "three": 3.0})
     assert r.zadd("foo", map_to_add, gt=True, ch=True) == expected_ret
@@ -118,7 +116,7 @@ def test_zadd_with_gt_and_ch(
     ids=["no_additions", "partial_additions", "new_additions"],
 )
 def test_zadd_with_gt(
-    r: ClientType, map_to_add: Dict[str, float], expected_ret: int, expected_zrange_state: List[Tuple[bytes, float]]
+    r: ClientType, map_to_add: dict[str, float], expected_ret: int, expected_zrange_state: list[tuple[bytes, float]]
 ):
     r.zadd("foo", {"four": 4.0, "three": 3.0})
     assert r.zadd("foo", map_to_add, gt=True) == expected_ret
@@ -137,7 +135,7 @@ def test_zadd_with_gt(
     ids=["no_additions", "partial_additions", "new_additions"],
 )
 def test_zadd_with_ch(
-    r: ClientType, map_to_add: Dict[str, float], expected_ret: int, expected_zrange_state: List[Tuple[bytes, float]]
+    r: ClientType, map_to_add: dict[str, float], expected_ret: int, expected_zrange_state: list[tuple[bytes, float]]
 ):
     r.zadd("foo", {"four": 4.0, "three": 3.0})
     assert r.zadd("foo", map_to_add, ch=True) == expected_ret
@@ -158,9 +156,9 @@ def test_zadd_with_ch(
 @pytest.mark.parametrize("ch", [False, True])
 def test_zadd_with_xx(
     r: ClientType,
-    map_to_add: Dict[str, float],
+    map_to_add: dict[str, float],
     expected_ret: int,
-    expected_zrange_state: List[Tuple[bytes, float]],
+    expected_zrange_state: list[tuple[bytes, float]],
     ch: bool,
 ):
     r.zadd("foo", {"four": 4.0, "three": 3.0})

--- a/test/test_mixins/test_specific_redis_versions/test_redis_8_4_msetex.py
+++ b/test/test_mixins/test_specific_redis_versions/test_redis_8_4_msetex.py
@@ -75,7 +75,7 @@ def test_msetex_expiration_px_with_cluster_client(r: ClientType):
     # with expiration - testing px field
     assert r.msetex(mapping=mapping, px=60000) == 1
 
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     for ttl in ttls:
         assert pytest.approx(ttl) == 60
     assert r.mget(*mapping.keys()) == [b"1", b"2"]
@@ -106,7 +106,7 @@ def test_msetex_expiration_pxat_and_nx_with_cluster_client(r: ClientType):
         == 0
     )
 
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     for ttl in ttls:
         assert 10 < ttl <= 30
     assert r.mget(*mapping.keys(), "new:{test:1}") == [b"1", b"2", b"three", None]
@@ -120,7 +120,7 @@ def test_msetex_expiration_pxat_and_nx_with_cluster_client(r: ClientType):
         )
         == 1
     )
-    old_ttls = [r.ttl(key) for key in mapping.keys()]
+    old_ttls = [r.ttl(key) for key in mapping]
     new_ttls = [r.ttl(key) for key in ["new:{test:1}", "new_2:{test:1}"]]
     for ttl in old_ttls:
         assert 10 < ttl <= 30
@@ -153,7 +153,7 @@ def test_msetex_expiration_exat_and_xx_with_cluster_client(r: ClientType):
         )
         == 0
     )
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     for ttl in ttls:
         assert 10 < ttl <= 30
     assert r.mget(*mapping.keys(), "new:{test:1}") == [b"1", b"2", b"three", None]
@@ -167,7 +167,7 @@ def test_msetex_expiration_exat_and_xx_with_cluster_client(r: ClientType):
         )
         == 1
     )
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     assert ttls[0] <= 11
     assert ttls[1] <= 11
     assert 10 < ttls[2] <= 30
@@ -225,7 +225,7 @@ def test_msetex_expiration_px(r: ClientType):
     # with expiration - testing px field
     assert r.msetex(mapping=mapping, px=60000) == 1
 
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     for ttl in ttls:
         assert pytest.approx(ttl) == 60
     assert r.mget(*mapping.keys()) == [b"1", b"2"]
@@ -249,7 +249,7 @@ def test_msetex_expiration_pxat_and_nx(r: ClientType):
         )
         == 0
     )
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     for ttl in ttls:
         assert 10 < ttl <= 30
     assert r.mget(*mapping.keys(), "new") == [b"1", b"2", b"three", None]
@@ -263,7 +263,7 @@ def test_msetex_expiration_pxat_and_nx(r: ClientType):
         )
         == 1
     )
-    old_ttls = [r.ttl(key) for key in mapping.keys()]
+    old_ttls = [r.ttl(key) for key in mapping]
     new_ttls = [r.ttl(key) for key in ["new", "new_2"]]
     for ttl in old_ttls:
         assert 10 < ttl <= 30
@@ -296,7 +296,7 @@ def test_msetex_expiration_exat_and_xx(r: ClientType):
         )
         == 0
     )
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     for ttl in ttls:
         assert 10 < ttl <= 30
     assert r.mget(*mapping.keys(), "new") == [b"1", b"2", b"three", None]
@@ -310,7 +310,7 @@ def test_msetex_expiration_exat_and_xx(r: ClientType):
         )
         == 1
     )
-    ttls = [r.ttl(key) for key in mapping.keys()]
+    ttls = [r.ttl(key) for key in mapping]
     assert ttls[0] <= 11
     assert ttls[1] <= 11
     assert 10 < ttls[2] <= 30

--- a/test/test_mixins/test_specific_redis_versions/test_redis_8_8_array_commands.py
+++ b/test/test_mixins/test_specific_redis_versions/test_redis_8_8_array_commands.py
@@ -11,7 +11,7 @@ pytestmark = [
     pytest.mark.unsupported_server_types("valkey"),
 ]
 try:
-    from redis.commands.core import ArrayAggregateOperations, ArrayPredicateType  # noqa: E402
+    from redis.commands.core import ArrayAggregateOperations, ArrayPredicateType
 except ImportError:
     pytest.skip("Array commands are not supported in this redis-py version", allow_module_level=True)
 

--- a/test/test_mixins/test_streams_commands.py
+++ b/test/test_mixins/test_streams_commands.py
@@ -1,6 +1,5 @@
 import threading
 import time
-from typing import List
 
 import pytest
 import redis
@@ -9,7 +8,7 @@ import valkey
 from fakeredis import _msgs as msgs
 from fakeredis._typing import ClientType
 from test import testtools
-from test.testtools import resp_conversion, get_protocol_version
+from test.testtools import get_protocol_version, resp_conversion
 
 
 def get_ids(results):
@@ -546,7 +545,7 @@ def test_xinfo_stream(r: ClientType):
     assert info["last-entry"] == get_stream_message(r, stream, m2)
 
 
-def assert_consumer_info(r: ClientType, stream: str, group: str, equal_keys: List) -> List:
+def assert_consumer_info(r: ClientType, stream: str, group: str, equal_keys: list) -> list:
     res = r.xinfo_consumers(stream, group)
     assert len(res) == len(equal_keys)
     for i in range(len(equal_keys)):
@@ -1000,7 +999,7 @@ def test_xreadgroup_pel_read_deleted_entry(r: ClientType):
 
 def test_xadd_change_time(r: ClientType):
     res = r.xadd("foobar", {"a": "1"})
-    ts, seq = res.decode().split("-")
+    ts, _seq = res.decode().split("-")
     new_ts = int(ts) - 10
     new_id = f"{new_ts}-*"
     with pytest.raises(Exception) as ctx:

--- a/test/test_mixins/test_string_commands.py
+++ b/test/test_mixins/test_string_commands.py
@@ -9,6 +9,7 @@ import valkey
 
 from fakeredis._helpers import current_time
 from fakeredis._typing import ClientType
+
 from .. import testtools
 from ..testtools import raw_command, resp_conversion
 
@@ -500,13 +501,13 @@ def test_saving_unicode_type_as_key(r: ClientType):
 
 def test_future_newbytes(r: ClientType):
     # bytes = pytest.importorskip('builtins', reason='future.types not available').bytes
-    r.set(bytes(b"\xc3\x91andu"), "foo")
+    r.set(b"\xc3\x91andu", "foo")
     assert r.get("Ñandu") == b"foo"
 
 
 def test_future_newstr(r: ClientType):
     # str = pytest.importorskip('builtins', reason='future.types not available').str
-    r.set(str("Ñandu"), "foo")
+    r.set("Ñandu", "foo")
     assert r.get("Ñandu") == b"foo"
 
 
@@ -518,7 +519,7 @@ def test_setitem_getitem(r: ClientType):
 
 def test_getitem_non_existent_key(r: ClientType):
     assert r.keys() == []
-    assert "noexists" not in r.keys()
+    assert "noexists" not in r
 
 
 @pytest.mark.slow

--- a/test/test_stack/test_bloomfilter.py
+++ b/test/test_stack/test_bloomfilter.py
@@ -3,8 +3,8 @@ import redis
 import valkey
 from redis.commands.bf import BFInfo
 
-from test import testtools
 from fakeredis import _msgs as msgs
+from test import testtools
 
 bloom_tests = pytest.importorskip("probables")
 

--- a/test/test_stack/test_json.py
+++ b/test/test_stack/test_json.py
@@ -423,7 +423,7 @@ def test_type(r: redis.Redis):
     r.json().set("1", Path.root_path(), 1)
 
     assert r.json().type("1", Path.root_path()) == testtools.resp_conversion(r, [b"integer"], b"integer")
-    assert r.json().type("1") == testtools.resp_conversion(r, [b"integer"], b"integer")  # noqa: E721
+    assert r.json().type("1") == testtools.resp_conversion(r, [b"integer"], b"integer")
 
     meta_data = {
         "object": {},
@@ -444,7 +444,7 @@ def test_type(r: redis.Redis):
             if v == val:
                 expected.append(k.encode())
                 break
-    assert r.json().type("doc1", "$..a") == testtools.resp_conversion(r, [expected], expected)  # noqa: E721
+    assert r.json().type("doc1", "$..a") == testtools.resp_conversion(r, [expected], expected)
 
     # Test single
     assert r.json().type("doc1", "$.integer.a") == testtools.resp_conversion(r, [[b"integer"]], [b"integer"])
@@ -501,14 +501,12 @@ def test_objkeys(r: redis.Redis):
     r.json().set("obj", Path.root_path(), obj)
     keys = r.json().objkeys("obj", Path.root_path())
     keys.sort()
-    exp = [k.encode() for k in obj.keys()]
+    exp = [k.encode() for k in obj]
     exp.sort()
-    assert set(keys) == testtools.resp_conversion(r, {k.encode() for k in obj.keys()}, set(obj.keys()))
+    assert set(keys) == testtools.resp_conversion(r, {k.encode() for k in obj}, set(obj.keys()))
 
     r.json().set("obj", Path.root_path(), obj)
-    assert set(r.json().objkeys("obj")) == testtools.resp_conversion(
-        r, {k.encode() for k in obj.keys()}, set(obj.keys())
-    )
+    assert set(r.json().objkeys("obj")) == testtools.resp_conversion(r, {k.encode() for k in obj}, set(obj.keys()))
 
     assert r.json().objkeys("fakekey") is None
 

--- a/test/test_stack/test_json_commands.py
+++ b/test/test_stack/test_json_commands.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from typing import (
     Any,
-    Dict,
-    List,
-    Tuple,
 )
 
 import pytest
@@ -21,7 +18,7 @@ SAMPLE_DATA = {
 
 
 @pytest.fixture(scope="function")
-def json_data() -> Dict[str, Any]:
+def json_data() -> dict[str, Any]:
     """A module-scoped "blob" of JSON-encodable data."""
     return {
         "L1": {
@@ -65,7 +62,7 @@ def json_data() -> Dict[str, Any]:
     }
 
 
-def load_types_data(nested_key_name: str) -> Tuple[Dict[str, Any], List[bytes]]:
+def load_types_data(nested_key_name: str) -> tuple[dict[str, Any], list[bytes]]:
     """Generate a structure with sample of all types"""
     type_samples = {
         "object": {},
@@ -81,4 +78,4 @@ def load_types_data(nested_key_name: str) -> Tuple[Dict[str, Any], List[bytes]]:
     for k, v in type_samples.items():
         jdata[f"nested_{k}"] = {nested_key_name: v}
 
-    return jdata, [k.encode() for k in type_samples.keys()]
+    return jdata, [k.encode() for k in type_samples]

--- a/test/test_stack/test_tdigest.py
+++ b/test/test_stack/test_tdigest.py
@@ -111,7 +111,7 @@ def test_tdigest_trimmed_mean(r: redis.Redis):
 
 def test_tdigest_rank(r: redis.Redis):
     assert r.tdigest().create("t-digest", 500)
-    assert r.tdigest().add("t-digest", list(range(0, 20)))
+    assert r.tdigest().add("t-digest", list(range(20)))
     assert -1 == r.tdigest().rank("t-digest", -1)[0]
     assert 0 == r.tdigest().rank("t-digest", 0)[0]
     assert 10 == r.tdigest().rank("t-digest", 10)[0]
@@ -120,7 +120,7 @@ def test_tdigest_rank(r: redis.Redis):
 
 def test_tdigest_revrank(r: redis.Redis):
     assert r.tdigest().create("t-digest", 500)
-    assert r.tdigest().add("t-digest", list(range(0, 20)))
+    assert r.tdigest().add("t-digest", list(range(20)))
     assert -1 == r.tdigest().revrank("t-digest", 20)[0]
     assert 19 == r.tdigest().revrank("t-digest", 0)[0]
     assert [-1, 19, 9] == r.tdigest().revrank("t-digest", 21, 0, 10)

--- a/test/test_stack/test_timeseries.py
+++ b/test/test_stack/test_timeseries.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import time
 from time import sleep

--- a/test/test_stack/test_timeseries.py
+++ b/test/test_stack/test_timeseries.py
@@ -1,14 +1,14 @@
 import math
 import time
 from time import sleep
-from typing import Dict, Any, AnyStr
+from typing import Any, AnyStr
 
 import pytest
 import redis
 import valkey
 
 from fakeredis import _msgs as msgs
-from test.testtools import raw_command, get_protocol_version, resp_conversion, resp_conversion_from_resp2
+from test.testtools import get_protocol_version, raw_command, resp_conversion, resp_conversion_from_resp2
 
 timeseries_tests = pytest.importorskip("probables")
 pytestmark = []
@@ -21,7 +21,7 @@ pytestmark.extend(
 
 
 class InfoClass:
-    def __init__(self, r: redis.Redis, response: Dict[AnyStr, Any]):
+    def __init__(self, r: redis.Redis, response: dict[AnyStr, Any]):
         if get_protocol_version(r) == 2:
             self.rules = response.get("rules")
             self.source_key = response.get("source_key")

--- a/test/test_stack/test_timeseries_multi_aggregators.py
+++ b/test/test_stack/test_timeseries_multi_aggregators.py
@@ -3,7 +3,7 @@
 import pytest
 
 from fakeredis._typing import ClientType
-from test.testtools import raw_command, get_protocol_version
+from test.testtools import get_protocol_version, raw_command
 
 timeseries_tests = pytest.importorskip("probables")
 

--- a/test/test_stack/test_topk.py
+++ b/test/test_stack/test_topk.py
@@ -2,7 +2,7 @@ import pytest
 import redis
 import valkey
 
-from test.testtools import resp_conversion, get_protocol_version
+from test.testtools import get_protocol_version, resp_conversion
 
 topk_tests = pytest.importorskip("probables")
 

--- a/test/test_stack/test_vectorset.py
+++ b/test/test_stack/test_vectorset.py
@@ -1,7 +1,6 @@
 import json
 import math
 import random
-from typing import List
 
 import pytest
 
@@ -647,7 +646,7 @@ def test_vrandmember(r: ClientType):
     random_member = r.vset().vrandmember("myset")
     assert random_member.decode() in elements
 
-    members_list: List[bytes] = r.vset().vrandmember("myset", count=2)
+    members_list: list[bytes] = r.vset().vrandmember("myset", count=2)
     assert len(members_list) == 2
     assert all(member.decode() in elements for member in members_list)
 
@@ -715,7 +714,7 @@ def test_vset_commands_without_decoding_responses(r: ClientType):
     # test vadd
     elements = ["elem1", "elem2", "elem3"]
     for elem in elements:
-        float_array = [random.uniform(0.5, 10) for x in range(0, 8)]
+        float_array = [random.uniform(0.5, 10) for x in range(8)]
         resp = r.vset().vadd("myset", float_array, element=elem)
         assert resp == 1
 

--- a/test/test_subkey_notifications.py
+++ b/test/test_subkey_notifications.py
@@ -4,6 +4,8 @@ Subkey notifications are controlled by the `notify-keyspace-events` config: the 
 enables hash-command events, and each of the S/T/I/V flags enables one subkey channel type.
 """
 
+from __future__ import annotations
+
 import time
 
 import pytest

--- a/test/test_subkey_notifications.py
+++ b/test/test_subkey_notifications.py
@@ -5,7 +5,6 @@ enables hash-command events, and each of the S/T/I/V flags enables one subkey ch
 """
 
 import time
-from typing import List, Tuple
 
 import pytest
 
@@ -23,7 +22,7 @@ pytestmark.extend(
 )
 
 
-def collect_messages(pubsub, timeout=1.0) -> List[Tuple[bytes, bytes]]:
+def collect_messages(pubsub, timeout=1.0) -> list[tuple[bytes, bytes]]:
     """Collect (channel, data) of pmessages until no message arrives within a short poll window."""
     deadline = time.time() + timeout
     messages = []

--- a/test/test_tcp_server/test_connectivity.py
+++ b/test/test_tcp_server/test_connectivity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 import time
 from threading import Thread

--- a/test/test_tcp_server/test_connectivity.py
+++ b/test/test_tcp_server/test_connectivity.py
@@ -1,13 +1,11 @@
 import threading
 import time
 from threading import Thread
-from typing import Tuple
 
 import pytest
 import redis
 
 from fakeredis._tcp_server import TcpFakeServer
-
 
 pytestmark = []
 pytestmark.extend(
@@ -17,13 +15,13 @@ pytestmark.extend(
 )
 
 
-def test_tcp_server_started(tcp_server_address: Tuple[str, int]):
+def test_tcp_server_started(tcp_server_address: tuple[str, int]):
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1]) as r:
         r.set("foo", "bar")
         assert r.get("foo") == b"bar"
 
 
-def test_tcp_server_connection_reset_error(tcp_server_address: Tuple[str, int]):
+def test_tcp_server_connection_reset_error(tcp_server_address: tuple[str, int]):
     with redis.Redis(*tcp_server_address) as r:
         r.rpush("test", b"foo")
 
@@ -31,10 +29,10 @@ def test_tcp_server_connection_reset_error(tcp_server_address: Tuple[str, int]):
         assert r.rpop("test") == b"foo"
 
 
-def test_bulk_string_length(real_server_address: Tuple[str, int], tcp_server_address: Tuple[str, int]):
+def test_bulk_string_length(real_server_address: tuple[str, int], tcp_server_address: tuple[str, int]):
     """Test that malformed bulk string input is handled correctly."""
-    from contextlib import closing
     import socket
+    from contextlib import closing
 
     connections = [real_server_address, tcp_server_address]
     for conn in connections:
@@ -48,7 +46,7 @@ def test_bulk_string_length(real_server_address: Tuple[str, int], tcp_server_add
             )
 
 
-def test_tcp_server_started_protocol_3(tcp_server_address: Tuple[str, int]):
+def test_tcp_server_started_protocol_3(tcp_server_address: tuple[str, int]):
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1], protocol=3) as r:
         r.set("foo", "bar")
         assert r.get("foo") == b"bar"

--- a/test/test_tcp_server/test_pubsub.py
+++ b/test/test_tcp_server/test_pubsub.py
@@ -1,7 +1,6 @@
 import threading
 import time
 from queue import Queue
-from typing import Tuple
 
 import pytest
 import redis
@@ -14,12 +13,10 @@ pytestmark.extend(
 )
 
 
-def test_pubsub(tcp_server_address: Tuple[str, int]):
+def test_pubsub(tcp_server_address: tuple[str, int]):
     def _listen(pubsub, q):
-        count = 0
-        for message in pubsub.listen():
+        for count, message in enumerate(pubsub.listen(), start=1):
             q.put(message)
-            count += 1
             if count == 4:
                 pubsub.close()
 

--- a/test/test_tcp_server/test_pubsub.py
+++ b/test/test_tcp_server/test_pubsub.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 import time
 from queue import Queue

--- a/test/test_tcp_server/test_scripting.py
+++ b/test/test_tcp_server/test_scripting.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import pytest
 import redis
 import valkey
@@ -15,7 +13,7 @@ pytestmark.extend(
 )
 
 
-def test_evalsha_missing_script(tcp_server_address: Tuple[str, int]):
+def test_evalsha_missing_script(tcp_server_address: tuple[str, int]):
     """Test that EVALSHA with a non-existent script returns NOSCRIPT error."""
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1]) as r:
         fake_sha = "0" * 40
@@ -25,7 +23,7 @@ def test_evalsha_missing_script(tcp_server_address: Tuple[str, int]):
         assert isinstance(ctx.value, (redis.exceptions.NoScriptError, valkey.exceptions.NoScriptError))
 
 
-def test_tcp_server_lock(tcp_server_address: Tuple[str, int]):
+def test_tcp_server_lock(tcp_server_address: tuple[str, int]):
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1]) as r:
         lock = Lock(r, "my-lock")
         lock.acquire()
@@ -33,7 +31,7 @@ def test_tcp_server_lock(tcp_server_address: Tuple[str, int]):
         lock.release()
 
 
-def test_eval_multiline_script(tcp_server_address: Tuple[str, int]):
+def test_eval_multiline_script(tcp_server_address: tuple[str, int]):
     """Test that EVAL works with multi-line Lua scripts."""
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1]) as r:
         # Multi-line script with trailing newline
@@ -47,7 +45,7 @@ return redis.call('GET', key)
         assert result == b"testvalue"
 
 
-def test_script_load_multiline(tcp_server_address: Tuple[str, int]):
+def test_script_load_multiline(tcp_server_address: tuple[str, int]):
     """Test that SCRIPT LOAD works with multi-line Lua scripts."""
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1]) as r:
         # Multi-line script
@@ -59,7 +57,7 @@ return x + y"""
         assert result == 3
 
 
-def test_eval_script_with_trailing_newline(tcp_server_address: Tuple[str, int]):
+def test_eval_script_with_trailing_newline(tcp_server_address: tuple[str, int]):
     """Test that scripts with trailing newlines are preserved."""
     with redis.Redis(host=tcp_server_address[0], port=tcp_server_address[1]) as r:
         # Script with explicit trailing newline

--- a/test/test_tcp_server/test_scripting.py
+++ b/test/test_tcp_server/test_scripting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import redis
 import valkey

--- a/test/test_valkey/test_valkey_init_args.py
+++ b/test/test_valkey/test_valkey_init_args.py
@@ -1,4 +1,5 @@
 import pytest
+
 import fakeredis
 
 


### PR DESCRIPTION
## Summary

Updating Ruff to 0.16 significantly expanded its **default** rule set (the project has no `[tool.ruff.lint].select`, so it relies on defaults), surfacing ~1587 lint errors. This makes `uv run ruff check` pass again, and sets the Ruff target to **`py38`** with the library verified to import and run on **Python 3.8**.

## What changed

- **Type-hint modernization**: `typing.List/Dict/Optional/Union` → PEP 585/604 builtins and `X | Y`, with `from __future__ import annotations` added wherever those appear in annotations (mandatory on 3.8 — Ruff `FA102`).
- **Python 3.8 runtime safety**: the few type expressions that are *evaluated at runtime* (so `from __future__` can't defer them) use `typing` aliases instead of PEP 585 builtins:
  - `_typing.py`: `VersionType`/`JsonType` → `Tuple`/`Dict`/`List`
  - `model/_client_info.py`: `class ClientInfo(Dict[str, Any])`
  - `commands_mixins/hash_mixin.py`: `cast(List[bytes], ...)`
- **Mechanical cleanups**: import sorting/pruning, comprehensions, `super()`, collapsible `if`s, dict `.items()` iteration, `enumerate`, `ClassVar` on mutable class attrs, and aligning `_vectorset.py`'s `Self` import with the `_typing` shim.
- **`[tool.ruff.lint]` config**: a small, commented set of ignores where the flagged pattern is intentional (`BLE001`, `S112`, and per-file `B017`/`DTZ`/`SIM115` test patterns).
- Added the `Programming Language :: Python :: 3.8` classifier.

## Verification

- `ruff check` + `ruff format` clean at `target-version = "py38"`.
- **CPython 3.8.20**: imported every submodule and ran a functional smoke test (strings, hashes + `hscan`, lists, sets, zsets, geo, streams, expiry, JSON, Bloom, Lua scripting, and the `valkey` client) — all pass, confirming no PEP 585/604 syntax leaked into a runtime-evaluated position.
- `mypy fakeredis/` — 0 net-new errors (42 pre-existing, environment-related).
- Full `-m fake` suite: **2458 passed** (the only excluded tests are `test_vset_commands_without_decoding_responses`, a pre-existing local `redis-server` VSIM env quirk).

## Not included

The `test`/`dev` dependency groups are still gated `python_version >= '3.9'`, so **CI does not yet run the suite on 3.8**. Adding a 3.8 CI leg would require relaxing those markers and confirming the test tooling (pytest/hypothesis/coverage/…) supports 3.8 — happy to do that as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)