### PR TITLE
Cache `JSONPath` objects in the JSON stack mixin

### DIFF
--- a/fakeredis/stack/_json_mixin.py
+++ b/fakeredis/stack/_json_mixin.py
@@ -6,6 +6,7 @@ import copy
 import itertools
 import json
 import struct
+from functools import lru_cache
 from json import JSONDecodeError
 from typing import Any, Callable, ClassVar
 
@@ -35,6 +36,7 @@ def _format_path(path: bytes | str) -> str:
         return "$." + path_str
 
 
+@lru_cache(maxsize=64)
 def _parse_jsonpath(path: str | bytes) -> JSONPath:
     path_str: str = _format_path(path)
     try:


### PR DESCRIPTION
This heavily optimizes operations on the JSON stack methods. In particular, I've noticed in my own project that `JSONPath` parsing at the object's constructor was being a heavy source of time in automated tests, in particular because it was recreating them on every operation.

Since this parsing is only dependent on the string key being used on its creation, we can cache previous results without loss of functionality.

The caching method and max size parameter where made in accordance with previous optimizations, such as the one in a30ceebe for VectorSets.

A simple benchmark was ran as following:
Command: `hyperfine -w 2 -r 10 "uv run pytest -v -k json"`

Results before this patch:
`Time (mean ± σ): 12.289 s ± 0.206 s [User: 12.802 s, System: 0.174 s]`

Results after this patch:
`Time (mean ± σ):  3.593 s ± 0.052 s [User: 4.200 s, System: 0.151 s]`